### PR TITLE
fix/improve midi1 midi2 conversion

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,58 @@
+Language: Cpp
+BasedOnStyle: LLVM
+
+# General Formatting
+AccessModifierOffset: -4
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 0
+ContinuationIndentWidth: 4
+LineEnding: LF
+
+# Braces and Wrapping
+BreakBeforeBraces: Attach
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+
+# Indentation Details
+IndentCaseLabels: false
+IndentExternBlock: NoIndent
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWrappedFunctionNames: false
+
+# Spacing
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
+AlignOperands: Align
+AlignTrailingComments: true
+PointerAlignment: Left
+
+# Includes
+SortIncludes: true
+
+# Misc
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+ReflowComments: false

--- a/cmidi2.h
+++ b/cmidi2.h
@@ -2022,6 +2022,13 @@ static inline uint32_t cmidi2_midi1_get_message_size(uint8_t* bytes, uint32_t le
                 break;
         bytes++;
         break;
+    case CMIDI2_SYSTEM_STATUS_TIMING_CLOCK:
+    case CMIDI2_SYSTEM_STATUS_START:
+    case CMIDI2_SYSTEM_STATUS_CONTINUE:
+    case CMIDI2_SYSTEM_STATUS_STOP:
+    case CMIDI2_SYSTEM_STATUS_ACTIVE_SENSING:
+        bytes += 1;
+        break;
     case 0xFF:
         bytes++;
         metaLength = cmidi2_midi1_get_7bit_encoded_int(bytes, end - bytes);
@@ -2241,18 +2248,24 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
         } else {
             // fixed sized message
             size_t remaining = sLen - *sIdx;
-            size_t len = cmidi2_midi1_get_message_size(context->midi1 + *sIdx, remaining);
-            if (len > remaining)
+            size_t inputMidi1Len = cmidi2_midi1_get_message_size(context->midi1 + *sIdx, remaining);
+            if (inputMidi1Len > remaining)
                 return CMIDI2_CONVERSION_RESULT_INVALID_INPUT;
 
-            uint8_t byte2 = context->midi1[*sIdx + 1];
-            uint8_t byte3 = len > 2 ? context->midi1[*sIdx + 2] : 0;
+            uint8_t byte2 = inputMidi1Len > 1 ? context->midi1[*sIdx + 1] : 0;
+            uint8_t byte3 = inputMidi1Len > 2 ? context->midi1[*sIdx + 2] : 0;
             uint8_t channel = status & 0xF;
             if (context->midi_protocol == CMIDI2_PROTOCOL_TYPE_MIDI1) {
                 // generate MIDI1 UMPs
-                dst[*dIdx] = cmidi2_ump_midi1_message(context->group, status & 0xF0, channel, byte2, byte3);
-                *sIdx += len;
-                *dIdx += 4;
+                if (status > 0xF0) {
+                    dst[*dIdx] = cmidi2_ump_system_message(context->group, status, byte2, byte3);
+                    *sIdx += inputMidi1Len;
+                    *dIdx += 4;
+                } else {
+                    dst[*dIdx] = cmidi2_ump_midi1_message(context->group, status & 0xF0, channel, byte2, byte3);
+                    *sIdx += inputMidi1Len;
+                    *dIdx += 4;
+                }
             } else {
                 // generate MIDI2 UMPs
                 uint64_t m2;
@@ -2260,15 +2273,19 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                 const int16_t NO_ATTRIBUTE_DATA = 0;
                 bool bankValid, bankMsbValid, bankLsbValid;
                 bool skipEmitUmp = false;
+                int outputUmpLen = 0;
                 switch (status & 0xF0) {
                 case CMIDI2_STATUS_NOTE_OFF:
                     m2 = cmidi2_ump_midi2_note_off(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                    outputUmpLen = 2;
                     break;
                 case CMIDI2_STATUS_NOTE_ON:
                     m2 = cmidi2_ump_midi2_note_on(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                    outputUmpLen = 2;
                     break;
                 case CMIDI2_STATUS_PAF:
                     m2 = cmidi2_ump_midi2_paf(context->group, channel, byte2, byte3 << 25);
+                    outputUmpLen = 2;
                     break;
                 case CMIDI2_STATUS_CC:
                     switch (byte2) {
@@ -2291,9 +2308,10 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                     case CMIDI2_CC_DTE_MSB:
                         context->context_dte = (context->context_dte & 0xFF) | (byte3 << 8);
 
-                        if (context->allow_reordered_dte && (context->context_dte & 0x8080) == 0)
+                        if (context->allow_reordered_dte && (context->context_dte & 0x8080) == 0) {
                             m2 = cmidi2_internal_convert_midi1_dte_to_ump(context, channel);
-                        else
+                            outputUmpLen = 2;
+                        } else
                             skipEmitUmp = true;
 
                         break;
@@ -2305,6 +2323,7 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                         if ((context->context_rpn & 0x8080) && (context->context_nrpn & 0x8080))
                             return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
                         m2 = cmidi2_internal_convert_midi1_dte_to_ump(context, channel);
+                        outputUmpLen = 2;
 
                         break;
                     case CMIDI2_CC_BANK_SELECT:
@@ -2317,6 +2336,7 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                         break;
                     default:
                         m2 = cmidi2_ump_midi2_cc(context->group, channel, byte2, byte3 << 25);
+                        outputUmpLen = 2;
                         break;
                     }
                     break;
@@ -2331,21 +2351,25 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                     break;
                 case CMIDI2_STATUS_CAF:
                     m2 = cmidi2_ump_midi2_caf(context->group, channel, byte2 << 25);
+                    outputUmpLen = 2;
                     break;
                 case CMIDI2_STATUS_PITCH_BEND:
                     // Note: Pitch Bend values in the MIDI 1.0 Protocol are presented as Little Endian.
                     m2 = cmidi2_ump_midi2_pitch_bend_direct(context->group, channel, ((byte3 << 7) + byte2) << 18);
+                    outputUmpLen = 2;
                     break;
                 default:
                     switch (status) {
                     case CMIDI2_SYSTEM_STATUS_MIDI_TIME_CODE:
                     case CMIDI2_SYSTEM_STATUS_SONG_SELECT:
-                        len = 2;
+                        inputMidi1Len = 2;
                         m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
+                        outputUmpLen = 2;
                         break;
                     case CMIDI2_SYSTEM_STATUS_SONG_POSITION:
-                        len = 3;
+                        inputMidi1Len = 3;
                         m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
+                        outputUmpLen = 2;
                         break;
                     case CMIDI2_SYSTEM_STATUS_TUNE_REQUEST:
                     case CMIDI2_SYSTEM_STATUS_TIMING_CLOCK:
@@ -2353,8 +2377,9 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                     case CMIDI2_SYSTEM_STATUS_STOP:
                     case CMIDI2_SYSTEM_STATUS_ACTIVE_SENSING:
                     case CMIDI2_SYSTEM_STATUS_RESET:
-                        len = 1;
+                        inputMidi1Len = 1;
                         m2 = cmidi2_ump_system_message(context->group, status, 0, 0);
+                        outputUmpLen = 1;
                         break;
                     default:
                         return CMIDI2_CONVERSION_RESULT_INVALID_STATUS;
@@ -2362,16 +2387,29 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                     break;
                 }
                 if (!skipEmitUmp) {
-                    int platEndian = cmidi2_util_is_platform_little_endian() ? CMIDI2_TRANSLATOR_LITTLE_ENDIAN : CMIDI2_TRANSLATOR_BIG_ENDIAN;
-                    int actualEndian = context->ump_serialization_endianness != CMIDI2_TRANSLATOR_DEFAULT_ENDIAN ? context->ump_serialization_endianness : platEndian;
-                    if (platEndian != actualEndian)
-                        m2 = (((uint64_t) cmidi2_internal_swap_endian(m2 >> 32)) << 32) | cmidi2_internal_swap_endian(m2 & 0xFFFFFFFF);
-                    *(uint32_t*) (dst + *dIdx) = m2 >> 32;
-                    *dIdx += 4;
-                    *(uint32_t*) (dst + *dIdx) = m2 & 0xFFFFFFFF;
-                    *dIdx += 4;
+                    switch (outputUmpLen) {
+                    case 1:
+                        *(uint32_t*) (dst + *dIdx) = m2;
+                        *dIdx += 4;
+                        break;
+                    case 2: {
+                        int platEndian = cmidi2_util_is_platform_little_endian()
+                                             ? CMIDI2_TRANSLATOR_LITTLE_ENDIAN
+                                             : CMIDI2_TRANSLATOR_BIG_ENDIAN;
+                        int actualEndian = context->ump_serialization_endianness != CMIDI2_TRANSLATOR_DEFAULT_ENDIAN
+                                               ? context->ump_serialization_endianness
+                                               : platEndian;
+                        if (platEndian != actualEndian)
+                            m2 = (((uint64_t) cmidi2_internal_swap_endian(m2 >> 32)) << 32) | cmidi2_internal_swap_endian(m2 & 0xFFFFFFFF);
+                        *(uint32_t*) (dst + *dIdx) = m2 >> 32;
+                        *dIdx += 4;
+                        *(uint32_t*) (dst + *dIdx) = m2 & 0xFFFFFFFF;
+                        *dIdx += 4;
+                        break;
+                    }
+                    }
                 }
-                *sIdx += len;
+                *sIdx += inputMidi1Len;
             }
         }
     }

--- a/cmidi2.h
+++ b/cmidi2.h
@@ -2,9 +2,9 @@
 #ifndef CMIDI2_H_INCLUDED
 #define CMIDI2_H_INCLUDED
 
+#include <memory.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <memory.h>
 
 #define CMIDI2_MIDI_2_0_RESERVED 0
 #define CMIDI2_JR_TIMESTAMP_TICKS_PER_SECOND 31250
@@ -65,8 +65,8 @@ enum cmidi2_ci_protocol_extensions {
 
 typedef struct cmidi2_ci_protocol_tag {
     uint8_t protocol_type; // cmidi2_ci_protocol_bytes
-    uint8_t version; // cmidi2_ci_protocol_values
-    uint8_t extensions; // cmidi2_ci_protocol_extensions (flags)
+    uint8_t version;       // cmidi2_ci_protocol_values
+    uint8_t extensions;    // cmidi2_ci_protocol_extensions (flags)
     uint8_t reserved1;
     uint8_t reserved2;
 } cmidi2_ci_protocol;
@@ -229,7 +229,6 @@ enum cmidi2_utility_message_status {
     CMIDI2_UTILITY_STATUS_DELTA_CLOCKSTAMP = 0x40,
 };
 
-
 enum cmidi2_flex_data_status_bank {
     CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE = 0,
     CMIDI2_FLEX_DATA_BANK_METADATA_TEXT = 1,
@@ -316,7 +315,6 @@ enum cmidi2_ump_chord_name_chord_type {
     CMIDI2_UMP_CHORD_TYPE_7_SUSPENDED_4TH = 27,
 };
 
-
 static inline uint8_t cmidi2_ump_get_num_bytes(uint32_t data) {
     switch (((data & 0xF0000000) >> 28) & 0xF) {
     case CMIDI2_MESSAGE_TYPE_UTILITY:
@@ -382,8 +380,7 @@ static inline cmidi2_ump128_t cmidi2_ump_endpoint_discovery(cmidi2_ump_version_t
         (uint32_t) ((CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (CMIDI2_UMP_STREAM_STATUS_ENDPOINT_DISCOVERY << 16) + (version.major << 8) + version.minor),
         (uint32_t) (filterBitmap & 0x1F),
         0,
-        0
-        };
+        0};
     return ret;
 }
 
@@ -392,8 +389,7 @@ static inline cmidi2_ump128_t cmidi2_ump_endpoint_info_notification(cmidi2_ump_v
         (uint32_t) (CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (CMIDI2_UMP_STREAM_STATUS_ENDPOINT_INFO << 16) + (version.major << 8) + version.minor,
         (uint32_t) (isStaticFunctionBlock ? 1 << 31 : 0) + (numFunctionBlocks << 24) + (midi2Capable ? 0x1000 : 0) + (midi1Capable ? 0x100 : 0) + (rxJR ? 2 : 0) + (txJR ? 1 : 0),
         0,
-        0
-        };
+        0};
     return ret;
 }
 
@@ -403,8 +399,7 @@ static inline cmidi2_ump128_t cmidi2_ump_device_identity_notification(uint32_t m
         (uint32_t) (CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (CMIDI2_UMP_STREAM_STATUS_DEVICE_IDENTITY << 16),
         manufacturerIdIn7bitArray,
         (uint32_t) (deviceFamilyLSB << 24) + (deviceFamilyMSB << 16) + (deviceFamilyModelLSB << 8) + deviceFamilyMSB,
-        softwareRevisionIn7bitArray
-        };
+        softwareRevisionIn7bitArray};
     return ret;
 }
 
@@ -413,17 +408,16 @@ static inline cmidi2_ump128_t cmidi2_ump_internal_name_notification(uint8_t stat
         (uint32_t) (CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (statusCode << 16) + (name[0] << 8) + name[1],
         (uint32_t) (name[2] << 24) + (name[3] << 16) + (name[4] << 8) + name[5],
         (uint32_t) (name[6] << 24) + (name[7] << 16) + (name[8] << 8) + name[9],
-        (uint32_t) (name[10] << 24) + (name[11] << 16) + (name[12] << 8) + name[13]
-        };
+        (uint32_t) (name[10] << 24) + (name[11] << 16) + (name[12] << 8) + name[13]};
     return ret;
 }
 
 static inline cmidi2_ump128_t cmidi2_ump_endpoint_name_notification(const char name[14]) {
-    return cmidi2_ump_internal_name_notification( CMIDI2_UMP_STREAM_STATUS_ENDPOINT_NAME, name);
+    return cmidi2_ump_internal_name_notification(CMIDI2_UMP_STREAM_STATUS_ENDPOINT_NAME, name);
 }
 
 static inline cmidi2_ump128_t cmidi2_ump_product_instance_id_notification(const char id[14]) {
-    return cmidi2_ump_internal_name_notification( CMIDI2_UMP_STREAM_STATUS_PRODUCT_INSTANCE_ID, id);
+    return cmidi2_ump_internal_name_notification(CMIDI2_UMP_STREAM_STATUS_PRODUCT_INSTANCE_ID, id);
 }
 
 static inline cmidi2_ump128_t cmidi2_ump_stream_configuration_request(uint8_t protocol, bool rxJR, bool txJR) {
@@ -449,8 +443,7 @@ static inline cmidi2_ump128_t cmidi2_ump_function_block_discovery(uint8_t numFun
         (uint32_t) (CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (CMIDI2_UMP_STREAM_STATUS_FUNCTION_BLOCK_DISCOVERY << 16) + (numFunctionBlocks << 8) + filter,
         0,
         0,
-        0
-        };
+        0};
     return ret;
 }
 
@@ -459,13 +452,12 @@ static inline cmidi2_ump128_t cmidi2_ump_function_block_info_notification(bool a
         (uint32_t) (CMIDI2_MESSAGE_TYPE_UMP_STREAM << 28) + (CMIDI2_UMP_STREAM_STATUS_FUNCTION_BLOCK_INFO << 16) + (active ? 0x8000 : 0) + (numFunctionBlocks << 8) + (uiHint << 4) + (midi1 << 2) + direction,
         (uint32_t) (firstGroup << 24) + (numSpannedGroup << 16) + (midiCIVersionFormat << 8) + maxNumSysEx8Streams,
         0,
-        0
-        };
+        0};
     return ret;
 }
 
 static inline cmidi2_ump128_t cmidi2_ump_function_block_name_notification(const char name[14]) {
-    return cmidi2_ump_internal_name_notification( CMIDI2_UMP_STREAM_STATUS_FUNCTION_BLOCK_NAME, name);
+    return cmidi2_ump_internal_name_notification(CMIDI2_UMP_STREAM_STATUS_FUNCTION_BLOCK_NAME, name);
 }
 
 static inline cmidi2_ump128_t cmidi2_ump_start_of_clip() {
@@ -479,7 +471,9 @@ static inline cmidi2_ump128_t cmidi2_ump_end_of_clip() {
 }
 
 // 7.2 Utility Messages
-static inline uint32_t cmidi2_ump_noop() { return 0; }
+static inline uint32_t cmidi2_ump_noop() {
+    return 0;
+}
 
 static inline uint32_t cmidi2_ump_jr_clock_direct(uint16_t senderClockTime) {
     return (CMIDI2_UTILITY_STATUS_JR_CLOCK << 16) + senderClockTime;
@@ -569,7 +563,8 @@ static inline int64_t cmidi2_ump_midi2_channel_message_8_8_32(
 }
 
 static inline uint16_t cmidi2_ump_pitch_7_9(double semitone) {
-    double actual = semitone < 0.0 ? 0.0 : semitone >= 128.0 ? 128.0 : semitone;
+    double actual = semitone < 0.0 ? 0.0 : semitone >= 128.0 ? 128.0
+                                                             : semitone;
     uint16_t dec = (uint16_t) actual;
     double microtone = actual - dec;
     return (dec << 9) + (int) (microtone * 512.0);
@@ -577,7 +572,8 @@ static inline uint16_t cmidi2_ump_pitch_7_9(double semitone) {
 
 static inline uint16_t cmidi2_ump_pitch_7_9_split(uint8_t semitone, double microtone) {
     uint16_t ret = (uint16_t) (semitone & 0x7F) << 9;
-    double actual = microtone < 0.0 ? 0.0 : microtone > 1.0 ? 1.0 : microtone;
+    double actual = microtone < 0.0 ? 0.0 : microtone > 1.0 ? 1.0
+                                                            : microtone;
     ret += (int) (actual * 512.0);
     return ret;
 }
@@ -628,7 +624,7 @@ static inline int64_t cmidi2_ump_midi2_relative_nrpn(uint8_t group, uint8_t chan
 
 static inline int64_t cmidi2_ump_midi2_program(uint8_t group, uint8_t channel, uint8_t optionFlags, uint8_t program, uint8_t bankMSB, uint8_t bankLSB) {
     return cmidi2_ump_midi2_channel_message_8_8_32(group, CMIDI2_STATUS_PROGRAM, channel, MIDI_2_0_RESERVED, optionFlags & 1,
-        ((program & 0x7F) << 24) + (bankMSB << 8) + bankLSB);
+                                                   ((program & 0x7F) << 24) + (bankMSB << 8) + bankLSB);
 }
 
 static inline int64_t cmidi2_ump_midi2_caf(uint8_t group, uint8_t channel, uint32_t data) {
@@ -665,16 +661,16 @@ static inline size_t cmidi2_ump_sysex_get_num_packets(size_t numBytes, uint8_t r
     return numBytes <= radix ? 1 : (numBytes / radix + (numBytes % radix ? 1 : 0));
 }
 
-static inline uint32_t cmidi2_ump_read_uint32_bytes_le(const void *sequence) {
-    const uint8_t *bytes = (const uint8_t*) sequence;
+static inline uint32_t cmidi2_ump_read_uint32_bytes_le(const void* sequence) {
+    const uint8_t* bytes = (const uint8_t*) sequence;
     uint32_t ret = 0;
     for (int i = 0; i < 4; i++)
         ret += ((uint32_t) bytes[i]) << (i * 8);
     return ret;
 }
 
-static inline uint32_t cmidi2_ump_read_uint32_bytes_be(const void *sequence) {
-    const uint8_t *bytes = (const uint8_t*) sequence;
+static inline uint32_t cmidi2_ump_read_uint32_bytes_be(const void* sequence) {
+    const uint8_t* bytes = (const uint8_t*) sequence;
     uint32_t ret = 0;
     for (int i = 0; i < 4; i++)
         ret += ((uint32_t) bytes[i]) << ((3 - i) * 8);
@@ -686,34 +682,34 @@ static inline bool cmidi2_util_is_platform_little_endian() {
     return *(char*) &i;
 }
 
-static inline uint32_t cmidi2_ump_read_uint32_bytes(const void *sequence) {
+static inline uint32_t cmidi2_ump_read_uint32_bytes(const void* sequence) {
     return cmidi2_util_is_platform_little_endian() ? cmidi2_ump_read_uint32_bytes_le(sequence) : cmidi2_ump_read_uint32_bytes_be(sequence);
 }
 
-static inline uint64_t cmidi2_ump_read_uint64_bytes_le(const void *sequence) {
+static inline uint64_t cmidi2_ump_read_uint64_bytes_le(const void* sequence) {
     return ((uint64_t) cmidi2_ump_read_uint32_bytes_le(sequence) << 32) + cmidi2_ump_read_uint32_bytes_le((const uint8_t*) sequence + 4);
 }
 
-static inline uint64_t cmidi2_ump_read_uint64_bytes_be(const void *sequence) {
+static inline uint64_t cmidi2_ump_read_uint64_bytes_be(const void* sequence) {
     return ((uint64_t) cmidi2_ump_read_uint32_bytes_be(sequence) << 32) + cmidi2_ump_read_uint32_bytes_be((const uint8_t*) sequence + 4);
 }
 
-static inline uint64_t cmidi2_ump_read_uint64_bytes(const void *sequence) {
+static inline uint64_t cmidi2_ump_read_uint64_bytes(const void* sequence) {
     return cmidi2_util_is_platform_little_endian() ? cmidi2_ump_read_uint64_bytes_le(sequence) : cmidi2_ump_read_uint64_bytes_be(sequence);
 }
 
 static inline void cmidi2_ump_sysex_get_packet_of(uint64_t* result1, uint64_t* result2, uint8_t group, size_t numBytes, const void* srcData, int32_t index,
-        enum cmidi2_message_type messageType, int radix, bool hasStreamId, uint8_t streamId) {
+                                                  enum cmidi2_message_type messageType, int radix, bool hasStreamId, uint8_t streamId) {
     uint8_t dst8[16];
     memset(dst8, 0, 16);
-    const uint8_t *src8 = (const uint8_t*) srcData;
+    const uint8_t* src8 = (const uint8_t*) srcData;
 
     dst8[0] = (messageType << 4) + (group & 0xF);
 
     enum cmidi2_sysex_status status;
     uint8_t size;
     if (numBytes <= radix) {
-        status =  CMIDI2_SYSEX_IN_ONE_UMP;
+        status = CMIDI2_SYSEX_IN_ONE_UMP;
         size = numBytes; // single packet message
     } else if (index == 0) {
         status = CMIDI2_SYSEX_START;
@@ -745,13 +741,13 @@ static inline void cmidi2_ump_sysex_get_packet_of(uint64_t* result1, uint64_t* r
 // 7.7 System Exclusive 7-Bit Messages
 static inline uint64_t cmidi2_ump_sysex7_direct(uint8_t group, uint8_t status, uint8_t numBytes, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t data4, uint8_t data5, uint8_t data6) {
     return (((uint64_t) ((CMIDI2_MESSAGE_TYPE_SYSEX7 << 28) + ((group & 0xF) << 24) + ((status + numBytes) << 16))) << 32) +
-        ((uint64_t) data1 << 40) + ((uint64_t) data2 << 32) + (data3 << 24) + (data4 << 16) + (data5 << 8) + data6;
+           ((uint64_t) data1 << 40) + ((uint64_t) data2 << 32) + (data3 << 24) + (data4 << 16) + (data5 << 8) + data6;
 }
 
 static inline uint32_t cmidi2_ump_sysex7_get_sysex_length(const void* srcData) {
     int i = 0;
     const uint8_t* csrc = (const uint8_t*) srcData;
-    while (csrc[i] != 0xF7)        
+    while (csrc[i] != 0xF7)
         i++;
     /* This function automatically detects if 0xF0 is prepended and reduce length if it is. */
     return i - (csrc[0] == 0xF0 ? 1 : 0);
@@ -771,16 +767,15 @@ static inline uint64_t cmidi2_ump_sysex7_get_packet_of(uint8_t group, size_t num
 /* process() - more complicated function */
 
 // This returns NULL for success, or anything else for failure.
-typedef void*(*cmidi2_ump_handler_u64)(uint64_t data, void* context);
+typedef void* (*cmidi2_ump_handler_u64)(uint64_t data, void* context);
 
 // Processes sysex7 inputs where we do not always end at F7 and thus takes length as the argument.
 // This returns NULL for success, or anything else that `sendUMP` returns for failure.
-static inline void* cmidi2_ump_sysex7_process_n(uint8_t group, void* sysex, uint32_t length, cmidi2_ump_handler_u64 sendUMP, void* context)
-{
+static inline void* cmidi2_ump_sysex7_process_n(uint8_t group, void* sysex, uint32_t length, cmidi2_ump_handler_u64 sendUMP, void* context) {
     int32_t numPackets = cmidi2_ump_sysex7_get_num_packets(length);
     for (int p = 0; p < numPackets; p++) {
         int64_t ump = cmidi2_ump_sysex7_get_packet_of(group, length, sysex, p);
-        void *retCode = sendUMP(ump, context);
+        void* retCode = sendUMP(ump, context);
         if (retCode != 0)
             return retCode;
     }
@@ -806,11 +801,10 @@ static inline void cmidi2_ump_sysex8_get_packet_of(uint8_t group, uint8_t stream
 /* process() - more complicated function */
 
 // This returns NULL for success, or anything else for failure.
-typedef void*(*cmidi2_ump_handler_u128)(uint64_t data1, uint64_t data2, size_t index, void* context);
+typedef void* (*cmidi2_ump_handler_u128)(uint64_t data1, uint64_t data2, size_t index, void* context);
 
 // This returns NULL for success, or anything else that `sendUMP` returns for failure.
-static inline void* cmidi2_ump_sysex8_process(uint8_t group, void* sysex, uint32_t length, uint8_t streamId, cmidi2_ump_handler_u128 sendUMP, void* context)
-{
+static inline void* cmidi2_ump_sysex8_process(uint8_t group, void* sysex, uint32_t length, uint8_t streamId, cmidi2_ump_handler_u128 sendUMP, void* context) {
     uint32_t numPackets = cmidi2_ump_sysex8_get_num_packets(length);
     for (size_t p = 0; p < numPackets; p++) {
         uint64_t result1, result2;
@@ -837,9 +831,9 @@ static inline int32_t cmidi2_ump_mds_get_num_payloads(uint32_t numTotalBytesinCh
 }
 
 static inline void cmidi2_ump_mds_get_header(uint8_t group, uint8_t mdsId,
-    uint16_t numBytesInChunk, uint16_t numChunks, uint16_t chunkIndex,
-    uint16_t manufacturerId, uint16_t deviceId, uint16_t subId, uint16_t subId2,
-    uint64_t* result1, uint64_t* result2) {
+                                             uint16_t numBytesInChunk, uint16_t numChunks, uint16_t chunkIndex,
+                                             uint16_t manufacturerId, uint16_t deviceId, uint16_t subId, uint16_t subId2,
+                                             uint64_t* result1, uint64_t* result2) {
     uint8_t dst8[16];
     memset(dst8, 0, 16);
 
@@ -862,7 +856,7 @@ static inline void cmidi2_ump_mds_get_header(uint8_t group, uint8_t mdsId,
 static inline void cmidi2_ump_mds_get_payload_of(uint8_t group, uint8_t mdsId, uint16_t numBytes, const void* srcData, uint64_t* result1, uint64_t* result2) {
     uint8_t dst8[16];
     memset(dst8, 0, 16);
-    const uint8_t *src8 = (const uint8_t*) srcData;
+    const uint8_t* src8 = (const uint8_t*) srcData;
 
     dst8[0] = (CMIDI2_MESSAGE_TYPE_SYSEX8_MDS << 4) + (group & 0xF);
     dst8[1] = CMIDI2_MIXED_DATA_STATUS_PAYLOAD + mdsId;
@@ -880,15 +874,14 @@ static inline void cmidi2_ump_mds_get_payload_of(uint8_t group, uint8_t mdsId, u
 
 /* process() - more complicated function */
 // This returns NULL for success, or anything else for failure.
-typedef void*(*cmidi2_mds_handler)(uint64_t data1, uint64_t data2, size_t chunkId, size_t payloadId, void* context);
+typedef void* (*cmidi2_mds_handler)(uint64_t data1, uint64_t data2, size_t chunkId, size_t payloadId, void* context);
 
 // This returns NULL for success, or anything else that `sendUMP` returns for failure.
-static inline void* cmidi2_ump_mds_process(uint8_t group, uint8_t mdsId, void* data, uint32_t length, cmidi2_mds_handler sendUMP, void* context)
-{
+static inline void* cmidi2_ump_mds_process(uint8_t group, uint8_t mdsId, void* data, uint32_t length, cmidi2_mds_handler sendUMP, void* context) {
     int32_t numChunks = cmidi2_ump_mds_get_num_chunks(length);
     for (int c = 0; c < numChunks; c++) {
         int32_t maxChunkSize = 14 * 65535;
-        int32_t chunkSize = c + 1 == numChunks ? (int32_t)(length % maxChunkSize) : maxChunkSize;
+        int32_t chunkSize = c + 1 == numChunks ? (int32_t) (length % maxChunkSize) : maxChunkSize;
         int32_t numPayloads = cmidi2_ump_mds_get_num_payloads(chunkSize);
         for (int p = 0; p < numPayloads; p++) {
             uint64_t result1, result2;
@@ -909,8 +902,8 @@ static inline uint16_t cmidi2_ump_flex_data_get_num_packets(uint32_t numTotalByt
 }
 
 static inline void cmidi2_ump_flex_data_complete_packet(uint8_t group, uint8_t addressing, uint8_t channel,
-        uint8_t statusBank, uint8_t statusCode, uint32_t data1, uint32_t data2, uint32_t data3,
-        uint64_t* result1, uint64_t* result2) {
+                                                        uint8_t statusBank, uint8_t statusCode, uint32_t data1, uint32_t data2, uint32_t data3,
+                                                        uint64_t* result1, uint64_t* result2) {
     uint8_t dst8[4];
     memset(dst8, 0, 4);
     dst8[0] = (CMIDI2_MESSAGE_TYPE_FLEX_DATA << 4) + (group & 0xF);
@@ -923,11 +916,11 @@ static inline void cmidi2_ump_flex_data_complete_packet(uint8_t group, uint8_t a
 }
 
 static inline void cmidi2_ump_flex_data_get_packet_of(uint8_t group, uint8_t addressing, uint8_t channel,
-        uint8_t statusBank, uint8_t statusCode, uint16_t numBytes, const void* srcData, int32_t currentPacket,
-        uint64_t* result1, uint64_t* result2) {
+                                                      uint8_t statusBank, uint8_t statusCode, uint16_t numBytes, const void* srcData, int32_t currentPacket,
+                                                      uint64_t* result1, uint64_t* result2) {
     uint8_t dst8[16];
     memset(dst8, 0, 16);
-    const uint8_t *src8 = (const uint8_t*) srcData;
+    const uint8_t* src8 = (const uint8_t*) srcData;
 
     dst8[0] = (CMIDI2_MESSAGE_TYPE_FLEX_DATA << 4) + (group & 0xF);
 
@@ -935,7 +928,7 @@ static inline void cmidi2_ump_flex_data_get_packet_of(uint8_t group, uint8_t add
     enum cmidi2_sysex_status format;
     uint8_t size;
     if (numBytes <= radix) {
-        format =  CMIDI2_SYSEX_IN_ONE_UMP;
+        format = CMIDI2_SYSEX_IN_ONE_UMP;
         size = numBytes; // single packet message
     } else if (currentPacket == 0) {
         format = CMIDI2_SYSEX_START;
@@ -968,13 +961,12 @@ typedef void* (*cmidi2_flex_data_handler)(uint64_t data1, uint64_t data2, void* 
 // This returns NULL for success, or anything else that `sendUMP` returns for failure.
 // `text` is usually a null-terminated text string, but it may contain `\0` as Melisma in lyricText. Hence we still need `length`.
 static inline void* cmidi2_ump_flex_data_process(uint8_t group, uint8_t addressing, uint8_t channel,
-        uint8_t statusBank, uint8_t statusCode, const char* text, uint32_t length, cmidi2_flex_data_handler sendUMP, void* context)
-{
+                                                 uint8_t statusBank, uint8_t statusCode, const char* text, uint32_t length, cmidi2_flex_data_handler sendUMP, void* context) {
     int32_t numPackets = cmidi2_ump_flex_data_get_num_packets(length);
     for (int p = 0; p < numPackets; p++) {
         uint64_t result1, result2;
         cmidi2_ump_flex_data_get_packet_of(group, addressing, channel, statusBank, statusCode, length, text, p, &result1, &result2);
-        void *retCode = sendUMP(result1, result2, context);
+        void* retCode = sendUMP(result1, result2, context);
         if (retCode != 0)
             return retCode;
     }
@@ -984,64 +976,63 @@ static inline void* cmidi2_ump_flex_data_process(uint8_t group, uint8_t addressi
 // individual flex data message generators
 
 static inline void cmidi2_ump_flex_data_set_tempo_direct(uint8_t group, uint8_t channel,
-        uint32_t tempoIn10NanosecondsPerQN,
-        uint64_t* result1, uint64_t* result2) {
+                                                         uint32_t tempoIn10NanosecondsPerQN,
+                                                         uint64_t* result1, uint64_t* result2) {
     cmidi2_ump_flex_data_complete_packet(group, 1, channel,
-        CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
-        CMIDI2_FLEX_DATA_STATUS_SET_TEMPO,
-        tempoIn10NanosecondsPerQN, 0, 0,
-        result1, result2);
+                                         CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
+                                         CMIDI2_FLEX_DATA_STATUS_SET_TEMPO,
+                                         tempoIn10NanosecondsPerQN, 0, 0,
+                                         result1, result2);
 }
 
 static inline void cmidi2_ump_flex_data_set_time_signature(uint8_t group, uint8_t channel,
-        uint8_t numerator, uint8_t denominator, uint8_t numberOf32thNotes, 
-        uint64_t* result1, uint64_t* result2) {
+                                                           uint8_t numerator, uint8_t denominator, uint8_t numberOf32thNotes,
+                                                           uint64_t* result1, uint64_t* result2) {
     cmidi2_ump_flex_data_complete_packet(group, 1, channel,
-        CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
-        CMIDI2_FLEX_DATA_STATUS_SET_TIME_SIGNATURE,
-        (numerator << 24) + (denominator << 16) + (numberOf32thNotes << 8),0, 0,
-        result1, result2);
+                                         CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
+                                         CMIDI2_FLEX_DATA_STATUS_SET_TIME_SIGNATURE,
+                                         (numerator << 24) + (denominator << 16) + (numberOf32thNotes << 8), 0, 0,
+                                         result1, result2);
 }
 
 static inline void cmidi2_ump_flex_data_set_metronome(uint8_t group, uint8_t channel,
-        uint8_t clocksPerPrimaryClick, uint8_t barAccent1, uint8_t barAccent2, uint8_t barAccent3, uint8_t subDivisionClicks1, uint8_t subDivisionClicks2,
-        uint64_t* result1, uint64_t* result2) {
+                                                      uint8_t clocksPerPrimaryClick, uint8_t barAccent1, uint8_t barAccent2, uint8_t barAccent3, uint8_t subDivisionClicks1, uint8_t subDivisionClicks2,
+                                                      uint64_t* result1, uint64_t* result2) {
     cmidi2_ump_flex_data_complete_packet(group, 1, channel,
-        CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
-        CMIDI2_FLEX_DATA_STATUS_SET_METRONOME,
-        (clocksPerPrimaryClick << 24) + (barAccent1 << 16) + (barAccent2 << 8) + barAccent3, (subDivisionClicks1 << 24) + (subDivisionClicks2 << 16), 0,
-        result1, result2);
+                                         CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
+                                         CMIDI2_FLEX_DATA_STATUS_SET_METRONOME,
+                                         (clocksPerPrimaryClick << 24) + (barAccent1 << 16) + (barAccent2 << 8) + barAccent3, (subDivisionClicks1 << 24) + (subDivisionClicks2 << 16), 0,
+                                         result1, result2);
 }
 
 static inline void cmidi2_ump_flex_data_set_key_signature(uint8_t group, uint8_t addressing, uint8_t channel,
-        uint8_t sharpsFlats, uint8_t tonicNote,
-        uint64_t* result1, uint64_t* result2) {
+                                                          uint8_t sharpsFlats, uint8_t tonicNote,
+                                                          uint64_t* result1, uint64_t* result2) {
     cmidi2_ump_flex_data_complete_packet(group, addressing, channel,
-        CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
-        CMIDI2_FLEX_DATA_STATUS_SET_KEY_SIGNATURE,
-        (sharpsFlats << 24) + (tonicNote << 16), 0, 0,
-        result1, result2);
+                                         CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
+                                         CMIDI2_FLEX_DATA_STATUS_SET_KEY_SIGNATURE,
+                                         (sharpsFlats << 24) + (tonicNote << 16), 0, 0,
+                                         result1, result2);
 }
 
 static inline void cmidi2_ump_flex_data_set_chord_name(uint8_t group, uint8_t addressing, uint8_t channel,
-        uint8_t sharpsFlats, uint8_t chordTonic, uint8_t chordType,
-        uint8_t alter1Type, uint8_t alter1Degree,
-        uint8_t alter2Type, uint8_t alter2Degree,
-        uint8_t alter3Type, uint8_t alter3Degree,
-        uint8_t alter4Type, uint8_t alter4Degree,
-        uint8_t bassSharpsFlats, uint8_t bassNote, uint8_t bassChordType,
-        uint8_t bassAlter1Type, uint8_t bassAlter1Degree,
-        uint8_t bassAlter2Type, uint8_t bassAlter2Degree,
-        uint64_t* result1, uint64_t* result2) {
+                                                       uint8_t sharpsFlats, uint8_t chordTonic, uint8_t chordType,
+                                                       uint8_t alter1Type, uint8_t alter1Degree,
+                                                       uint8_t alter2Type, uint8_t alter2Degree,
+                                                       uint8_t alter3Type, uint8_t alter3Degree,
+                                                       uint8_t alter4Type, uint8_t alter4Degree,
+                                                       uint8_t bassSharpsFlats, uint8_t bassNote, uint8_t bassChordType,
+                                                       uint8_t bassAlter1Type, uint8_t bassAlter1Degree,
+                                                       uint8_t bassAlter2Type, uint8_t bassAlter2Degree,
+                                                       uint64_t* result1, uint64_t* result2) {
     cmidi2_ump_flex_data_complete_packet(group, addressing, channel,
-        CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
-        CMIDI2_FLEX_DATA_STATUS_SET_CHORD_NAME,
-        (sharpsFlats << 28) + (chordTonic << 24) + (chordType << 16) + (alter1Type << 12) + (alter1Degree << 8) + (alter2Type << 4) + alter2Degree,
-        (alter3Type << 28) + (alter3Degree << 24) + (alter4Type << 20) + (alter4Degree << 16),
-        (bassSharpsFlats << 28) + (bassNote << 24) + (bassChordType << 16) + (bassAlter1Type << 12) + (bassAlter1Degree << 8) + (bassAlter2Type << 4) + bassAlter2Degree,
-        result1, result2);
+                                         CMIDI2_FLEX_DATA_BANK_SETUP_AND_PERFORMANCE,
+                                         CMIDI2_FLEX_DATA_STATUS_SET_CHORD_NAME,
+                                         (sharpsFlats << 28) + (chordTonic << 24) + (chordType << 16) + (alter1Type << 12) + (alter1Degree << 8) + (alter2Type << 4) + alter2Degree,
+                                         (alter3Type << 28) + (alter3Degree << 24) + (alter4Type << 20) + (alter4Degree << 16),
+                                         (bassSharpsFlats << 28) + (bassNote << 24) + (bassChordType << 16) + (bassAlter1Type << 12) + (bassAlter1Degree << 8) + (bassAlter2Type << 4) + bassAlter2Degree,
+                                         result1, result2);
 }
-
 
 // --------
 // Strongly-typed(?) UMP.
@@ -1083,15 +1074,15 @@ static inline uint8_t cmidi2_ump_get_message_type(const cmidi2_ump* ump) {
 
 static inline uint8_t cmidi2_ump_get_message_size_bytes(const cmidi2_ump* ump) {
     switch (cmidi2_ump_get_message_type(ump)) {
-        case CMIDI2_MESSAGE_TYPE_UTILITY:
-        case CMIDI2_MESSAGE_TYPE_SYSTEM:
-        case CMIDI2_MESSAGE_TYPE_MIDI_1_CHANNEL:
-            return 4;
-        case CMIDI2_MESSAGE_TYPE_SYSEX7:
-        case CMIDI2_MESSAGE_TYPE_MIDI_2_CHANNEL:
-            return 8;
-        case CMIDI2_MESSAGE_TYPE_SYSEX8_MDS:
-            return 16;
+    case CMIDI2_MESSAGE_TYPE_UTILITY:
+    case CMIDI2_MESSAGE_TYPE_SYSTEM:
+    case CMIDI2_MESSAGE_TYPE_MIDI_1_CHANNEL:
+        return 4;
+    case CMIDI2_MESSAGE_TYPE_SYSEX7:
+    case CMIDI2_MESSAGE_TYPE_MIDI_2_CHANNEL:
+        return 8;
+    case CMIDI2_MESSAGE_TYPE_SYSEX8_MDS:
+        return 16;
     }
     return 0; // invalid
 }
@@ -1345,7 +1336,7 @@ enum cmidi2_ump_binary_reader_result_code {
 
 typedef struct cmidi2_ump_binary_read_state {
     void* context;
-    uint8_t *data;
+    uint8_t* data;
     size_t dataCapacity;
     size_t dataSize;
     bool continueOnCompletion;
@@ -1359,7 +1350,7 @@ static inline void cmidi2_ump_binary_read_state_reset(cmidi2_ump_binary_read_sta
 
 static inline void cmidi2_ump_binary_read_state_init(cmidi2_ump_binary_read_state* state,
                                                      void* context,
-                                                     uint8_t *dataBuffer,
+                                                     uint8_t* dataBuffer,
                                                      size_t dataCapacity,
                                                      bool continueOnCompletion) {
     state->context = context;
@@ -1375,7 +1366,7 @@ static inline void cmidi2_ump_binary_read_state_init(cmidi2_ump_binary_read_stat
 /// Note that the resulting state must contain a non-null data and valid dataCapacity i.e. it must be already assigned.
 /// Also note that the function implementation should not try to allocate a new instance of state
 /// - otherwise it will break realtime safety.
-typedef cmidi2_ump_binary_read_state*(*cmidi2_ump_stream_selector_func)(uint8_t targetStreamId, void* context);
+typedef cmidi2_ump_binary_read_state* (*cmidi2_ump_stream_selector_func)(uint8_t targetStreamId, void* context);
 
 /// Binary stream continuity checker for cmidi2_ump_get_sysex8_data() function.
 /// If you do not support simultaneous streams, then it should reset stream state (dataSize etc.) when new stream starts.
@@ -1384,7 +1375,7 @@ typedef cmidi2_ump_binary_read_state*(*cmidi2_ump_stream_selector_func)(uint8_t 
 /// `cmidi2_ump_get_sysex8_data()` can take NULL for this function pointer at `continuityChecker` argument,
 /// then it falls back to the "default" behavior.
 /// By default, it finishes parsing when a stream completed and `continueOnCompletion` was `false`.
-typedef bool(*cmidi2_ump_binary_read_continuity_checker_func)(cmidi2_ump_binary_read_state* stream, cmidi2_ump* ump);
+typedef bool (*cmidi2_ump_binary_read_continuity_checker_func)(cmidi2_ump_binary_read_state* stream, cmidi2_ump* ump);
 
 // it is a special copy function that only works with sysex8 memory state at `src` that can access beyond `sizeInBytes`.
 static inline void cmidi2_internal_sysex8_copy_data_byte_swapping(uint8_t* dst, uint8_t srcHead, uint32_t* srcTail, size_t sizeInBytes) {
@@ -1414,27 +1405,27 @@ static inline void cmidi2_internal_sysex8_copy_data_byte_swapping(uint8_t* dst, 
 /// Parse and store sysex8 binary, using some fine-tuned behavioral functions.
 /// Return the number of 32-bit ints (number of `cmidi2_ump`s)
 static inline size_t cmidi2_ump_get_sysex8_data(
-        cmidi2_ump_stream_selector_func streamSelector,
-        void* streamSelectorContext,
-        cmidi2_ump_binary_read_continuity_checker_func continuityChecker,
-        const cmidi2_ump* ump,
-        const size_t umpCapacityInInt) {
+    cmidi2_ump_stream_selector_func streamSelector,
+    void* streamSelectorContext,
+    cmidi2_ump_binary_read_continuity_checker_func continuityChecker,
+    const cmidi2_ump* ump,
+    const size_t umpCapacityInInt) {
 
     cmidi2_ump *umpPtr = (cmidi2_ump*) ump, *umpEnd = (cmidi2_ump*) ump + umpCapacityInInt;
-    for (;umpPtr < umpEnd; umpPtr += cmidi2_ump_get_message_size_bytes(umpPtr) / sizeof(cmidi2_ump)) {
+    for (; umpPtr < umpEnd; umpPtr += cmidi2_ump_get_message_size_bytes(umpPtr) / sizeof(cmidi2_ump)) {
         if (cmidi2_ump_get_message_type(umpPtr) != CMIDI2_MESSAGE_TYPE_SYSEX8_MDS)
             continue;
         switch (cmidi2_ump_get_status_code(umpPtr)) {
-            case CMIDI2_SYSEX_IN_ONE_UMP:
-            case CMIDI2_SYSEX_START:
-            case CMIDI2_SYSEX_END:
-            case CMIDI2_SYSEX_CONTINUE:
-                break;
-            default:
-                continue; // the only expected value here is MDS (8 or 9)
+        case CMIDI2_SYSEX_IN_ONE_UMP:
+        case CMIDI2_SYSEX_START:
+        case CMIDI2_SYSEX_END:
+        case CMIDI2_SYSEX_CONTINUE:
+            break;
+        default:
+            continue; // the only expected value here is MDS (8 or 9)
         }
 
-        cmidi2_ump_binary_read_state *state = streamSelector(cmidi2_ump_get_sysex8_stream_id(umpPtr), streamSelectorContext);
+        cmidi2_ump_binary_read_state* state = streamSelector(cmidi2_ump_get_sysex8_stream_id(umpPtr), streamSelectorContext);
         if (state == NULL)
             continue;
 
@@ -1458,12 +1449,12 @@ static inline size_t cmidi2_ump_get_sysex8_data(
 
         // otherwise default continuity checker
         switch (cmidi2_ump_get_status_code(umpPtr)) {
-            case CMIDI2_SYSEX_IN_ONE_UMP:
-            case CMIDI2_SYSEX_END:
-                state->resultCode = CMIDI2_BINARY_READER_RESULT_COMPLETE;
-                if (state->continueOnCompletion)
-                    return umpPtr + cmidi2_ump_get_message_size_bytes(umpPtr) / sizeof(cmidi2_ump) - ump; // default "break here" condition.
-                break;
+        case CMIDI2_SYSEX_IN_ONE_UMP:
+        case CMIDI2_SYSEX_END:
+            state->resultCode = CMIDI2_BINARY_READER_RESULT_COMPLETE;
+            if (state->continueOnCompletion)
+                return umpPtr + cmidi2_ump_get_message_size_bytes(umpPtr) / sizeof(cmidi2_ump) - ump; // default "break here" condition.
+            break;
         }
     }
     // finished parsing while no stream indicated "break here" for completion.
@@ -1481,27 +1472,27 @@ static inline void* cmidi2_ump_sequence_next(const void* ptr) {
 
 // similar to LV2_ATOM Utilities API...
 #define CMIDI2_UMP_SEQUENCE_FOREACH(ptr, numBytes, iter) \
-    for (uint8_t* (iter) = (uint8_t*) ptr; \
-        (iter) < ((uint8_t*) ptr) + numBytes; \
-        (iter) = (uint8_t*) cmidi2_ump_sequence_next(iter))
+    for (uint8_t*(iter) = (uint8_t*) ptr;                \
+         (iter) < ((uint8_t*) ptr) + numBytes;           \
+         (iter) = (uint8_t*) cmidi2_ump_sequence_next(iter))
 
 static inline void* cmidi2_ump_sequence_next_le(const void* ptr) {
     return (uint8_t*) ptr + cmidi2_ump_get_num_bytes(cmidi2_ump_read_uint32_bytes_le(ptr));
 }
 
 #define CMIDI2_UMP_SEQUENCE_FOREACH_LE(ptr, numBytes, iter) \
-    for (uint8_t* (iter) = (uint8_t*) ptr; \
-        (iter) < ((uint8_t*) ptr) + numBytes; \
-        (iter) = (uint8_t*) cmidi2_ump_sequence_next_le(iter))
+    for (uint8_t*(iter) = (uint8_t*) ptr;                   \
+         (iter) < ((uint8_t*) ptr) + numBytes;              \
+         (iter) = (uint8_t*) cmidi2_ump_sequence_next_le(iter))
 
 static inline void* cmidi2_ump_sequence_next_be(const void* ptr) {
     return (uint8_t*) ptr + cmidi2_ump_get_num_bytes(cmidi2_ump_read_uint32_bytes_be(ptr));
 }
 
 #define CMIDI2_UMP_SEQUENCE_FOREACH_BE(ptr, numBytes, iter) \
-    for (uint8_t* (iter) = (uint8_t*) ptr; \
-        (iter) < ((uint8_t*) ptr) + numBytes; \
-        (iter) = (uint8_t*) cmidi2_ump_sequence_next_be(iter))
+    for (uint8_t*(iter) = (uint8_t*) ptr;                   \
+         (iter) < ((uint8_t*) ptr) + numBytes;              \
+         (iter) = (uint8_t*) cmidi2_ump_sequence_next_be(iter))
 
 // --------
 // MIDI CI support.
@@ -1597,7 +1588,7 @@ static inline void cmidi2_ci_7bit_int28_at(uint8_t* buf, uint32_t v) {
 }
 
 static inline void cmidi2_ci_message_common(uint8_t* buf,
-        uint8_t destination, uint8_t sysexSubId2, uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID) {
+                                            uint8_t destination, uint8_t sysexSubId2, uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID) {
     buf[0] = 0x7E;
     buf[1] = destination;
     buf[2] = CMIDI2_CI_SUB_ID;
@@ -1610,10 +1601,10 @@ static inline void cmidi2_ci_message_common(uint8_t* buf,
 // Discovery
 
 static inline void cmidi2_ci_discovery_common(uint8_t* buf, uint8_t sysexSubId2,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
-    uint32_t deviceManufacturer3Bytes, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
-    uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
-    uint8_t initiatorOutputPathId) {
+                                              uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
+                                              uint32_t deviceManufacturer3Bytes, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
+                                              uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
+                                              uint8_t initiatorOutputPathId) {
     cmidi2_ci_message_common(buf, CMIDI2_CI_DEVICE_ID_WHOLE_FUNCTION_BLOCK, sysexSubId2, versionAndFormat, sourceMUID, destinationMUID);
     cmidi2_ci_direct_uint32_at(buf + 13, deviceManufacturer3Bytes); // the last byte is extraneous, but will be overwritten next.
     cmidi2_ci_direct_uint16_at(buf + 16, deviceFamily);
@@ -1626,40 +1617,40 @@ static inline void cmidi2_ci_discovery_common(uint8_t* buf, uint8_t sysexSubId2,
 }
 
 static inline void cmidi2_ci_discovery(uint8_t* buf,
-    uint8_t versionAndFormat, uint32_t sourceMUID,
-    uint32_t deviceManufacturer, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
-    uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
-    uint8_t initiatorOutputPathId) {
+                                       uint8_t versionAndFormat, uint32_t sourceMUID,
+                                       uint32_t deviceManufacturer, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
+                                       uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
+                                       uint8_t initiatorOutputPathId) {
     cmidi2_ci_discovery_common(buf, CMIDI2_CI_SUB_ID_2_DISCOVERY_INQUIRY,
-        versionAndFormat, sourceMUID, 0x7F7F7F7F,
-        deviceManufacturer, deviceFamily, deviceFamilyModelNumber,
-        softwareRevisionLevel, ciCategorySupported, receivableMaxSysExSize,
-        initiatorOutputPathId);
+                               versionAndFormat, sourceMUID, 0x7F7F7F7F,
+                               deviceManufacturer, deviceFamily, deviceFamilyModelNumber,
+                               softwareRevisionLevel, ciCategorySupported, receivableMaxSysExSize,
+                               initiatorOutputPathId);
 }
 
 static inline void cmidi2_ci_discovery_reply(uint8_t* buf,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
-    uint32_t deviceManufacturer, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
-    uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
-    uint8_t initiatorOutputPathId, uint8_t functionBlockOr7Fh) {
+                                             uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
+                                             uint32_t deviceManufacturer, uint16_t deviceFamily, uint16_t deviceFamilyModelNumber,
+                                             uint32_t softwareRevisionLevel, uint8_t ciCategorySupported, uint32_t receivableMaxSysExSize,
+                                             uint8_t initiatorOutputPathId, uint8_t functionBlockOr7Fh) {
     cmidi2_ci_discovery_common(buf, CMIDI2_CI_SUB_ID_2_DISCOVERY_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID,
-        deviceManufacturer, deviceFamily, deviceFamilyModelNumber,
-        softwareRevisionLevel, ciCategorySupported, receivableMaxSysExSize,
-        initiatorOutputPathId);
+                               versionAndFormat, sourceMUID, destinationMUID,
+                               deviceManufacturer, deviceFamily, deviceFamilyModelNumber,
+                               softwareRevisionLevel, ciCategorySupported, receivableMaxSysExSize,
+                               initiatorOutputPathId);
     buf[30] = functionBlockOr7Fh;
 }
 
 static inline void cmidi2_ci_discovery_invalidate_muid(uint8_t* buf,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t targetMUID) {
+                                                       uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t targetMUID) {
     cmidi2_ci_message_common(buf, 0x7F, CMIDI2_CI_SUB_ID_2_INVALIDATE_MUID, versionAndFormat, sourceMUID, 0x7F7F7F7F);
     cmidi2_ci_direct_uint32_at(buf + 13, targetMUID);
 }
 
 static inline void cmidi2_ci_ack_nak_common(uint8_t* buf, uint8_t deviceId,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t originalTransactionSubID2Class, uint8_t statusCode, uint8_t statusData,
-    uint8_t* details5Bytes, uint16_t messageLength, const char* messageText) {
+                                            uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
+                                            uint8_t originalTransactionSubID2Class, uint8_t statusCode, uint8_t statusData,
+                                            uint8_t* details5Bytes, uint16_t messageLength, const char* messageText) {
     cmidi2_ci_message_common(buf, deviceId, CMIDI2_CI_SUB_ID_2_ACK, versionAndFormat, sourceMUID, destinationMUID);
     buf[13] = originalTransactionSubID2Class;
     buf[14] = statusCode;
@@ -1670,19 +1661,19 @@ static inline void cmidi2_ci_ack_nak_common(uint8_t* buf, uint8_t deviceId,
 }
 
 static inline void cmidi2_ci_ack(uint8_t* buf, uint8_t deviceId,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t originalTransactionSubID2Class, uint8_t ackStatusCode, uint8_t ackStatusData,
-    uint8_t* ackDetails5Bytes, uint16_t messageLength, const char* messageText) {
+                                 uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
+                                 uint8_t originalTransactionSubID2Class, uint8_t ackStatusCode, uint8_t ackStatusData,
+                                 uint8_t* ackDetails5Bytes, uint16_t messageLength, const char* messageText) {
     cmidi2_ci_ack_nak_common(buf, deviceId, versionAndFormat, sourceMUID, destinationMUID,
-        originalTransactionSubID2Class, ackStatusCode, ackStatusData, ackDetails5Bytes, messageLength, messageText);
+                             originalTransactionSubID2Class, ackStatusCode, ackStatusData, ackDetails5Bytes, messageLength, messageText);
 }
 
 static inline void cmidi2_ci_nak(uint8_t* buf, uint8_t deviceId,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t originalTransactionSubID2Class, uint8_t nakStatusCode, uint8_t nakStatusData,
-    uint8_t* nakDetails5Bytes, uint16_t messageLength, const char* messageText) {
+                                 uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID,
+                                 uint8_t originalTransactionSubID2Class, uint8_t nakStatusCode, uint8_t nakStatusData,
+                                 uint8_t* nakDetails5Bytes, uint16_t messageLength, const char* messageText) {
     cmidi2_ci_ack_nak_common(buf, deviceId, versionAndFormat, sourceMUID, destinationMUID,
-        originalTransactionSubID2Class, nakStatusCode, nakStatusData, nakDetails5Bytes, messageLength, messageText);
+                             originalTransactionSubID2Class, nakStatusCode, nakStatusData, nakDetails5Bytes, messageLength, messageText);
 }
 
 // Protocol Negotiation
@@ -1703,49 +1694,51 @@ static inline void cmidi2_ci_protocols(uint8_t* buf, uint8_t numSupportedProtoco
 }
 
 static inline void cmidi2_ci_protocol_negotiation(uint8_t* buf, bool isReply,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t authorityLevel,
-    uint8_t numSupportedProtocols, cmidi2_ci_protocol_type_info* protocolTypes) {
+                                                  uint32_t sourceMUID, uint32_t destinationMUID,
+                                                  uint8_t authorityLevel,
+                                                  uint8_t numSupportedProtocols, cmidi2_ci_protocol_type_info* protocolTypes) {
     cmidi2_ci_message_common(buf, 0x7F,
-        isReply ? CMIDI2_CI_SUB_ID_2_PROTOCOL_NEGOTIATION_REPLY : CMIDI2_CI_SUB_ID_2_PROTOCOL_NEGOTIATION_INQUIRY,
-        1, sourceMUID, destinationMUID);
+                             isReply ? CMIDI2_CI_SUB_ID_2_PROTOCOL_NEGOTIATION_REPLY : CMIDI2_CI_SUB_ID_2_PROTOCOL_NEGOTIATION_INQUIRY,
+                             1, sourceMUID, destinationMUID);
     buf[13] = authorityLevel;
     cmidi2_ci_protocols(buf + 14, numSupportedProtocols, protocolTypes);
 }
 
 static inline void cmidi2_ci_protocol_set(uint8_t* buf,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t authorityLevel, cmidi2_ci_protocol_type_info newProtocolType) {
+                                          uint32_t sourceMUID, uint32_t destinationMUID,
+                                          uint8_t authorityLevel, cmidi2_ci_protocol_type_info newProtocolType) {
     cmidi2_ci_message_common(buf, 0x7F,
-        CMIDI2_CI_SUB_ID_2_SET_NEW_PROTOCOL,
-        1, sourceMUID, destinationMUID);
+                             CMIDI2_CI_SUB_ID_2_SET_NEW_PROTOCOL,
+                             1, sourceMUID, destinationMUID);
     buf[13] = authorityLevel;
     cmidi2_ci_protocol_info(buf + 14, newProtocolType);
 }
 
 static inline void cmidi2_ci_protocol_test(uint8_t* buf,
-    bool isInitiatorToResponder,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t authorityLevel, uint8_t* testData48Bytes) {
+                                           bool isInitiatorToResponder,
+                                           uint32_t sourceMUID, uint32_t destinationMUID,
+                                           uint8_t authorityLevel, uint8_t* testData48Bytes) {
     cmidi2_ci_message_common(buf, 0x7F,
-        isInitiatorToResponder ? CMIDI2_CI_SUB_ID_2_TEST_NEW_PROTOCOL_I2R : CMIDI2_CI_SUB_ID_2_TEST_NEW_PROTOCOL_R2I,
-        1, sourceMUID, destinationMUID);
+                             isInitiatorToResponder ? CMIDI2_CI_SUB_ID_2_TEST_NEW_PROTOCOL_I2R : CMIDI2_CI_SUB_ID_2_TEST_NEW_PROTOCOL_R2I,
+                             1, sourceMUID, destinationMUID);
     buf[13] = authorityLevel;
     memcpy(buf + 14, testData48Bytes, 48);
 }
 
 static inline void cmidi2_ci_protocol_confirm_established(uint8_t* buf,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t authorityLevel) {
+                                                          uint32_t sourceMUID, uint32_t destinationMUID,
+                                                          uint8_t authorityLevel) {
     cmidi2_ci_message_common(buf, 0x7F,
-        CMIDI2_CI_SUB_ID_2_CONFIRM_NEW_PROTOCOL_ESTABLISHED,
-        1, sourceMUID, destinationMUID);
+                             CMIDI2_CI_SUB_ID_2_CONFIRM_NEW_PROTOCOL_ESTABLISHED,
+                             1, sourceMUID, destinationMUID);
     buf[13] = authorityLevel;
 }
 
 static inline int32_t cmidi2_ci_try_parse_new_protocol(uint8_t* buf, size_t length) {
     return (length != 19 || buf[0] != 0x7E || buf[1] != 0x7F || buf[2] != CMIDI2_CI_SUB_ID ||
-            buf[3] != CMIDI2_CI_SUB_ID_2_SET_NEW_PROTOCOL || buf[4] != 1) ? 0 : buf[14];
+            buf[3] != CMIDI2_CI_SUB_ID_2_SET_NEW_PROTOCOL || buf[4] != 1)
+               ? 0
+               : buf[14];
 }
 
 // Profile Configuration
@@ -1759,19 +1752,19 @@ static inline void cmidi2_ci_profile(uint8_t* buf, cmidi2_profile_id info) {
 }
 
 static inline void cmidi2_ci_profile_inquiry(uint8_t* buf, uint8_t source,
-    uint32_t sourceMUID, uint32_t destinationMUID) {
+                                             uint32_t sourceMUID, uint32_t destinationMUID) {
     cmidi2_ci_message_common(buf, source,
-        CMIDI2_CI_SUB_ID_2_PROFILE_INQUIRY,
-        1, sourceMUID, destinationMUID);
+                             CMIDI2_CI_SUB_ID_2_PROFILE_INQUIRY,
+                             1, sourceMUID, destinationMUID);
 }
 
 static inline void cmidi2_ci_profile_inquiry_reply(uint8_t* buf, uint8_t source,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t numEnabledProfiles, cmidi2_profile_id* enabledProfiles,
-    uint8_t numDisabledProfiles, cmidi2_profile_id* disabledProfiles) {
+                                                   uint32_t sourceMUID, uint32_t destinationMUID,
+                                                   uint8_t numEnabledProfiles, cmidi2_profile_id* enabledProfiles,
+                                                   uint8_t numDisabledProfiles, cmidi2_profile_id* disabledProfiles) {
     cmidi2_ci_message_common(buf, source,
-        CMIDI2_CI_SUB_ID_2_PROFILE_INQUIRY_REPLY,
-        1, sourceMUID, destinationMUID);
+                             CMIDI2_CI_SUB_ID_2_PROFILE_INQUIRY_REPLY,
+                             1, sourceMUID, destinationMUID);
     buf[13] = numEnabledProfiles;
     for (int i = 0; i < numEnabledProfiles; i++)
         cmidi2_ci_profile(buf + 14 + i * 5, enabledProfiles[i]);
@@ -1782,26 +1775,26 @@ static inline void cmidi2_ci_profile_inquiry_reply(uint8_t* buf, uint8_t source,
 }
 
 static inline void cmidi2_ci_profile_set(uint8_t* buf, uint8_t destination, bool turnOn,
-    uint32_t sourceMUID, uint32_t destinationMUID, cmidi2_profile_id profile) {
+                                         uint32_t sourceMUID, uint32_t destinationMUID, cmidi2_profile_id profile) {
     cmidi2_ci_message_common(buf, destination,
-        turnOn ? CMIDI2_CI_SUB_ID_2_SET_PROFILE_ON : CMIDI2_CI_SUB_ID_2_SET_PROFILE_OFF,
-        1, sourceMUID, destinationMUID);
+                             turnOn ? CMIDI2_CI_SUB_ID_2_SET_PROFILE_ON : CMIDI2_CI_SUB_ID_2_SET_PROFILE_OFF,
+                             1, sourceMUID, destinationMUID);
     cmidi2_ci_profile(buf + 13, profile);
 }
 
 static inline void cmidi2_ci_profile_report(uint8_t* buf, uint8_t source, bool isEnabledReport,
-    uint32_t sourceMUID, cmidi2_profile_id profile) {
+                                            uint32_t sourceMUID, cmidi2_profile_id profile) {
     cmidi2_ci_message_common(buf, source,
-        isEnabledReport ? CMIDI2_CI_SUB_ID_2_PROFILE_ENABLED_REPORT : CMIDI2_CI_SUB_ID_2_PROFILE_DISABLED_REPORT,
-        1, sourceMUID, 0x7F7F7F7F);
+                             isEnabledReport ? CMIDI2_CI_SUB_ID_2_PROFILE_ENABLED_REPORT : CMIDI2_CI_SUB_ID_2_PROFILE_DISABLED_REPORT,
+                             1, sourceMUID, 0x7F7F7F7F);
     cmidi2_ci_profile(buf + 13, profile);
 }
 
 static inline void cmidi2_ci_profile_specific_data(uint8_t* buf, uint8_t source,
-    uint32_t sourceMUID, uint32_t destinationMUID, cmidi2_profile_id profile, uint32_t dataSize, void* data) {
+                                                   uint32_t sourceMUID, uint32_t destinationMUID, cmidi2_profile_id profile, uint32_t dataSize, void* data) {
     cmidi2_ci_message_common(buf, source,
-        CMIDI2_CI_SUB_ID_2_PROFILE_SPECIFIC_DATA,
-        1, sourceMUID, destinationMUID);
+                             CMIDI2_CI_SUB_ID_2_PROFILE_SPECIFIC_DATA,
+                             1, sourceMUID, destinationMUID);
     cmidi2_ci_profile(buf + 13, profile);
     cmidi2_ci_direct_uint32_at(buf + 18, dataSize);
     memcpy(buf + 22, data, dataSize);
@@ -1810,18 +1803,18 @@ static inline void cmidi2_ci_profile_specific_data(uint8_t* buf, uint8_t source,
 // Property Exchange
 
 static inline void cmidi2_ci_property_get_capabilities(uint8_t* buf, uint8_t destination, bool isReply,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t maxSupportedRequests) {
+                                                       uint32_t sourceMUID, uint32_t destinationMUID, uint8_t maxSupportedRequests) {
     cmidi2_ci_message_common(buf, destination,
-        isReply ? CMIDI2_CI_SUB_ID_2_PROPERTY_CAPABILITIES_REPLY : CMIDI2_CI_SUB_ID_2_PROPERTY_CAPABILITIES_INQUIRY,
-        1, sourceMUID, destinationMUID);
+                             isReply ? CMIDI2_CI_SUB_ID_2_PROPERTY_CAPABILITIES_REPLY : CMIDI2_CI_SUB_ID_2_PROPERTY_CAPABILITIES_INQUIRY,
+                             1, sourceMUID, destinationMUID);
     buf[13] = maxSupportedRequests;
 }
 
 // common to all of: has data & reply, get data & reply, set data & reply, subscribe & reply, notify
 static inline void cmidi2_ci_property_common(uint8_t* buf, uint8_t destination, uint8_t messageTypeSubId2,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t requestId, uint16_t headerSize, void* header,
-    uint16_t numChunks, uint16_t chunkIndex, uint16_t dataSize, void* data) {
+                                             uint32_t sourceMUID, uint32_t destinationMUID,
+                                             uint8_t requestId, uint16_t headerSize, void* header,
+                                             uint16_t numChunks, uint16_t chunkIndex, uint16_t dataSize, void* data) {
     cmidi2_ci_message_common(buf, destination, messageTypeSubId2, 1, sourceMUID, destinationMUID);
     buf[13] = requestId;
     cmidi2_ci_direct_uint16_at(buf + 14, headerSize);
@@ -1833,21 +1826,21 @@ static inline void cmidi2_ci_property_common(uint8_t* buf, uint8_t destination, 
 }
 
 static inline void cmidi2_ci_property_get_capabilities_reply(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t maxSupportedRequests,
-    uint8_t peMajorVersion, uint8_t peMinorVersion) {
+                                                             uint32_t sourceMUID, uint32_t destinationMUID, uint8_t maxSupportedRequests,
+                                                             uint8_t peMajorVersion, uint8_t peMinorVersion) {
     cmidi2_ci_message_common(buf, CMIDI2_CI_DEVICE_ID_WHOLE_FUNCTION_BLOCK, CMIDI2_CI_SUB_ID_2_PROPERTY_CAPABILITIES_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
     buf[13] = maxSupportedRequests;
     buf[14] = peMajorVersion;
     buf[15] = peMinorVersion;
 }
 
 static inline void cmidi2_ci_property_data_common(uint8_t* buf, uint8_t subId2,
-    uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                                  uint8_t versionAndFormat, uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                                  size_t headerSize, const uint8_t* headerData,
+                                                  uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_message_common(buf, CMIDI2_CI_DEVICE_ID_WHOLE_FUNCTION_BLOCK, subId2,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
     buf[13] = requestId;
     buf[14] = headerSize % 0xFF;
     buf[15] = headerSize / 0xFF;
@@ -1860,91 +1853,91 @@ static inline void cmidi2_ci_property_data_common(uint8_t* buf, uint8_t subId2,
 }
 
 static inline void cmidi2_ci_property_get_data(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData) {
+                                               uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                               size_t headerSize, const uint8_t* headerData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_GET_DATA,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, 1, 1, 0, NULL);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, 1, 1, 0, NULL);
 }
 
 static inline void cmidi2_ci_property_get_data_reply(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                                     uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                                     size_t headerSize, const uint8_t* headerData,
+                                                     uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_GET_DATA_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
 }
 
 static inline void cmidi2_ci_property_set_data(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                               uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                               size_t headerSize, const uint8_t* headerData,
+                                               uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_SET_DATA,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
 }
 
 static inline void cmidi2_ci_property_set_data_reply(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData) {
+                                                     uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                                     size_t headerSize, const uint8_t* headerData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_SET_DATA_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, 1, 1, 0, NULL);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, 1, 1, 0, NULL);
 }
 
 static inline void cmidi2_ci_property_subscribe(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                                uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                                size_t headerSize, const uint8_t* headerData,
+                                                uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_SUBSCRIBE,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
 }
 
 static inline void cmidi2_ci_property_subscribe_reply(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                                      uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                                      size_t headerSize, const uint8_t* headerData,
+                                                      uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_SUBSCRIBE_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
 }
 
 static inline void cmidi2_ci_property_notify(uint8_t* buf, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
-    size_t headerSize, const uint8_t* headerData,
-    uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
+                                             uint32_t sourceMUID, uint32_t destinationMUID, uint8_t requestId,
+                                             size_t headerSize, const uint8_t* headerData,
+                                             uint16_t numChunksInMessage, uint16_t currentChunk, uint16_t propertyDataLength, const char* propertyData) {
     cmidi2_ci_property_data_common(buf, CMIDI2_CI_SUB_ID_2_PROPERTY_NOTIFY,
-        versionAndFormat, sourceMUID, destinationMUID,
-        requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
+                                   versionAndFormat, sourceMUID, destinationMUID,
+                                   requestId, headerSize, headerData, numChunksInMessage, currentChunk, propertyDataLength, propertyData);
 }
 
 // Process Inquiry
 
 static inline void cmidi2_ci_process_get_capabilities(uint8_t* buf, uint8_t subId2, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID) {
+                                                      uint32_t sourceMUID, uint32_t destinationMUID) {
     (void) subId2;
     cmidi2_ci_message_common(buf, CMIDI2_CI_DEVICE_ID_WHOLE_FUNCTION_BLOCK, CMIDI2_CI_SUB_ID_2_PROCESS_GET_CAPABILITIES,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
 }
 
 static inline void cmidi2_ci_process_get_capabilities_reply(uint8_t* buf, uint8_t subId2, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID, uint8_t processInquirySupportedFeatures) {
+                                                            uint32_t sourceMUID, uint32_t destinationMUID, uint8_t processInquirySupportedFeatures) {
     (void) subId2;
     cmidi2_ci_message_common(buf, CMIDI2_CI_DEVICE_ID_WHOLE_FUNCTION_BLOCK, CMIDI2_CI_SUB_ID_2_PROCESS_GET_CAPABILITIES_REPLY,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
     buf[13] = processInquirySupportedFeatures;
 }
 
 static inline void cmidi2_ci_process_midi_report_common(uint8_t* buf, uint8_t deviceId, uint8_t subId2, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t messageDataControl, uint8_t requestedSystemMessages,
-    uint8_t requestedChannelControllerMessages,
-    uint8_t requestedNoteDataMessages) {
+                                                        uint32_t sourceMUID, uint32_t destinationMUID,
+                                                        uint8_t messageDataControl, uint8_t requestedSystemMessages,
+                                                        uint8_t requestedChannelControllerMessages,
+                                                        uint8_t requestedNoteDataMessages) {
     (void) subId2;
     cmidi2_ci_message_common(buf, deviceId, CMIDI2_CI_SUB_ID_2_PROCESS_GET_CAPABILITIES,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
     buf[13] = messageDataControl;
     buf[14] = requestedSystemMessages;
     buf[15] = 0; // reserved
@@ -1953,34 +1946,33 @@ static inline void cmidi2_ci_process_midi_report_common(uint8_t* buf, uint8_t de
 }
 
 static inline void cmidi2_ci_process_get_midi_report(uint8_t* buf, uint8_t deviceId, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t messageDataControl, uint8_t requestedSystemMessages,
-    uint8_t requestedChannelControllerMessages,
-    uint8_t requestedNoteDataMessages) {
+                                                     uint32_t sourceMUID, uint32_t destinationMUID,
+                                                     uint8_t messageDataControl, uint8_t requestedSystemMessages,
+                                                     uint8_t requestedChannelControllerMessages,
+                                                     uint8_t requestedNoteDataMessages) {
     cmidi2_ci_process_midi_report_common(buf, deviceId, CMIDI2_CI_SUB_ID_2_PROCESS_GET_MIDI_REPORT, versionAndFormat, sourceMUID, destinationMUID,
-        messageDataControl, requestedSystemMessages, requestedChannelControllerMessages, requestedNoteDataMessages);
+                                         messageDataControl, requestedSystemMessages, requestedChannelControllerMessages, requestedNoteDataMessages);
 }
 
 static inline void cmidi2_ci_process_get_midi_report_reply(uint8_t* buf, uint8_t deviceId, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID,
-    uint8_t messageDataControl, uint8_t requestedSystemMessages,
-    uint8_t requestedChannelControllerMessages,
-    uint8_t requestedNoteDataMessages) {
+                                                           uint32_t sourceMUID, uint32_t destinationMUID,
+                                                           uint8_t messageDataControl, uint8_t requestedSystemMessages,
+                                                           uint8_t requestedChannelControllerMessages,
+                                                           uint8_t requestedNoteDataMessages) {
     cmidi2_ci_process_midi_report_common(buf, deviceId, CMIDI2_CI_SUB_ID_2_PROCESS_GET_MIDI_REPORT_REPLY, versionAndFormat, sourceMUID, destinationMUID,
-        messageDataControl, requestedSystemMessages, requestedChannelControllerMessages, requestedNoteDataMessages);
+                                         messageDataControl, requestedSystemMessages, requestedChannelControllerMessages, requestedNoteDataMessages);
 }
 
 static inline void cmidi2_ci_process_get_midi_report_end(uint8_t* buf, uint8_t deviceId, uint8_t versionAndFormat,
-    uint32_t sourceMUID, uint32_t destinationMUID) {
+                                                         uint32_t sourceMUID, uint32_t destinationMUID) {
     cmidi2_ci_message_common(buf, deviceId, CMIDI2_CI_SUB_ID_2_PROCESS_GET_MIDI_REPORT_END,
-        versionAndFormat, sourceMUID, destinationMUID);
+                             versionAndFormat, sourceMUID, destinationMUID);
 }
 
 // Miscellaneous MIDI Utilities
 
 /** Encodes `value` into `bytes` stream. Returns the length of the encoded value in bytes. */
-static inline uint8_t cmidi2_midi1_write_7bit_encoded_int(uint8_t* bytes, uint32_t value)
-{
+static inline uint8_t cmidi2_midi1_write_7bit_encoded_int(uint8_t* bytes, uint32_t value) {
     uint8_t pos = 0;
     for (;; pos++) {
         bytes[pos] = value % 0x80;
@@ -1994,7 +1986,7 @@ static inline uint8_t cmidi2_midi1_write_7bit_encoded_int(uint8_t* bytes, uint32
 
 /** Returns the length of `value` when it would be encoded into a byte stream. */
 static inline uint8_t cmidi2_midi1_get_7bit_encoded_int_length(uint32_t value) {
-    for (uint8_t ret = 1; ; ret++) {
+    for (uint8_t ret = 1;; ret++) {
         if (value >= 0x80)
             value /= 0x80;
         else
@@ -2004,8 +1996,7 @@ static inline uint8_t cmidi2_midi1_get_7bit_encoded_int_length(uint32_t value) {
 }
 
 /** Returns the 7-bit encoded value in `bytes` stream of `length` bytes. */
-static inline uint32_t cmidi2_midi1_get_7bit_encoded_int(uint8_t* bytes, uint32_t length)
-{
+static inline uint32_t cmidi2_midi1_get_7bit_encoded_int(uint8_t* bytes, uint32_t length) {
     uint8_t* start = bytes;
     uint32_t value = 0;
     for (int digits = 0;; digits++) {
@@ -2025,28 +2016,28 @@ static inline uint32_t cmidi2_midi1_get_message_size(uint8_t* bytes, uint32_t le
     uint8_t* start = bytes;
     uint8_t* end = bytes + length;
     switch (bytes[0]) {
-        case 0xF0:
-            for (bytes++; bytes < end; bytes++)
-                if (*bytes == 0xF7)
-                    break;
-            bytes++;
-            break;
-        case 0xFF:
-            bytes++;
-            metaLength = cmidi2_midi1_get_7bit_encoded_int(bytes, end - bytes);
-            bytes += metaLength + cmidi2_midi1_get_7bit_encoded_int_length(metaLength);
+    case 0xF0:
+        for (bytes++; bytes < end; bytes++)
+            if (*bytes == 0xF7)
+                break;
+        bytes++;
+        break;
+    case 0xFF:
+        bytes++;
+        metaLength = cmidi2_midi1_get_7bit_encoded_int(bytes, end - bytes);
+        bytes += metaLength + cmidi2_midi1_get_7bit_encoded_int_length(metaLength);
+        break;
+    default:
+        switch (bytes[0] & 0xF0) {
+        case 0xC0:
+        case 0xD0:
+            bytes += 2;
             break;
         default:
-            switch (bytes[0] & 0xF0) {
-                case 0xC0:
-                case 0xD0:
-                    bytes += 2;
-                    break;
-                default:
-                    bytes += 3;
-                    break;
-            }
+            bytes += 3;
             break;
+        }
+        break;
     }
     return bytes - start;
 }
@@ -2095,7 +2086,7 @@ typedef struct cmidi2_midi_conversion_context {
     // TODO: implement support for it
     int32_t tempo;
     // input MIDI1 messages or SMF events.
-    uint8_t *midi1;
+    uint8_t* midi1;
     // size of the input stream to process in bytes
     size_t midi1_num_bytes;
     // it is updated as per cmidi2_convert_midi1_messages_to_ump() proceeds the MIDI1 stream.
@@ -2200,16 +2191,14 @@ static inline uint64_t cmidi2_internal_convert_midi1_dte_to_ump(cmidi2_midi_conv
     context->context_rpn = 0x8080;
     context->context_nrpn = 0x8080;
     context->context_dte = 0x8080;
-    return isRpn ?
-        cmidi2_ump_midi2_rpn(context->group, channel, msb, lsb, data) :
-        cmidi2_ump_midi2_nrpn(context->group, channel, msb, lsb, data);
+    return isRpn ? cmidi2_ump_midi2_rpn(context->group, channel, msb, lsb, data) : cmidi2_ump_midi2_nrpn(context->group, channel, msb, lsb, data);
 }
 
 static inline uint32_t cmidi2_internal_swap_endian(uint32_t v) {
     return ((v & 0xFF) << 24) +
-            (((v >> 8) & 0xFF) << 16) +
-            (((v >> 16) & 0xFF) << 8) +
-            ((v >> 24) & 0xFF);
+           (((v >> 8) & 0xFF) << 16) +
+           (((v >> 16) & 0xFF) << 8) +
+           ((v >> 24) & 0xFF);
 }
 
 /** converts MIDI1 bytestream which can contain deltaTime in SMF, to MIDI2 UMP stream.
@@ -2219,8 +2208,8 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
     uint8_t* dst = (uint8_t*) context->ump;
     size_t sLen = context->midi1_num_bytes;
     size_t dLen = context->ump_num_bytes;
-    uint8_t *sIdx = (uint8_t*) &context->midi1_proceeded_bytes;
-    uint8_t *dIdx = (uint8_t*) &context->ump_proceeded_bytes;
+    uint8_t* sIdx = (uint8_t*) &context->midi1_proceeded_bytes;
+    uint8_t* dIdx = (uint8_t*) &context->ump_proceeded_bytes;
 
     while (*sIdx < sLen) {
         // FIXME: implement deltaTime to JR Timestamp conversion.
@@ -2228,14 +2217,12 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
         uint8_t status = context->midi1[*sIdx];
         if (status == 0xF0) {
             // sysex
-            uint8_t *f7 = (uint8_t*) memchr(context->midi1 + *sIdx, 0xF7, context->midi1_num_bytes - *sIdx);
+            uint8_t* f7 = (uint8_t*) memchr(context->midi1 + *sIdx, 0xF7, context->midi1_num_bytes - *sIdx);
             if (f7 == NULL) {
                 return CMIDI2_CONVERSION_RESULT_INVALID_SYSEX; // error
             }
             size_t sysexSize = f7 - context->midi1 - *sIdx - 1; // excluding 0xF7
-            size_t numPackets = context->use_sysex8 ?
-                cmidi2_ump_sysex8_get_num_packets(sysexSize) :
-                cmidi2_ump_sysex7_get_num_packets(sysexSize);
+            size_t numPackets = context->use_sysex8 ? cmidi2_ump_sysex8_get_num_packets(sysexSize) : cmidi2_ump_sysex7_get_num_packets(sysexSize);
             if (dLen - *dIdx < numPackets)
                 return CMIDI2_CONVERSION_RESULT_OUT_OF_SPACE;
             cmidi2_convert_sysex_context sysExCtx;
@@ -2244,11 +2231,11 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
             if (context->use_sysex8) {
                 // ignoring the return code as it never returns non-NULL... (size is already verified)
                 cmidi2_ump_sysex8_process(context->group, context->midi1 + *sIdx, sysexSize, 0,
-                    cmidi2_internal_convert_add_midi1_sysex8_ump_to_list, &sysExCtx);
+                                          cmidi2_internal_convert_add_midi1_sysex8_ump_to_list, &sysExCtx);
             } else {
                 // ignoring the return code as it never returns non-NULL... (size is already verified)
                 cmidi2_ump_sysex7_process(context->group, context->midi1 + *sIdx,
-                    cmidi2_internal_convert_add_midi1_sysex7_ump_to_list, &sysExCtx);
+                                          cmidi2_internal_convert_add_midi1_sysex7_ump_to_list, &sysExCtx);
             }
             *sIdx += sysexSize + 1; // +1 for 0xF7
         } else {
@@ -2274,110 +2261,109 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
                 bool bankValid, bankMsbValid, bankLsbValid;
                 bool skipEmitUmp = false;
                 switch (status & 0xF0) {
-                    case CMIDI2_STATUS_NOTE_OFF:
-                        m2 = cmidi2_ump_midi2_note_off(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                case CMIDI2_STATUS_NOTE_OFF:
+                    m2 = cmidi2_ump_midi2_note_off(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                    break;
+                case CMIDI2_STATUS_NOTE_ON:
+                    m2 = cmidi2_ump_midi2_note_on(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                    break;
+                case CMIDI2_STATUS_PAF:
+                    m2 = cmidi2_ump_midi2_paf(context->group, channel, byte2, byte3 << 25);
+                    break;
+                case CMIDI2_STATUS_CC:
+                    switch (byte2) {
+                    case CMIDI2_CC_RPN_MSB:
+                        context->context_rpn = (context->context_rpn & 0xFF) | (byte3 << 8);
+                        skipEmitUmp = true;
                         break;
-                    case CMIDI2_STATUS_NOTE_ON:
-                        m2 = cmidi2_ump_midi2_note_on(context->group, channel, byte2, NO_ATTRIBUTE_TYPE, byte3 << 9, NO_ATTRIBUTE_DATA);
+                    case CMIDI2_CC_RPN_LSB:
+                        context->context_rpn = (context->context_rpn & 0xFF00) | byte3;
+                        skipEmitUmp = true;
                         break;
-                    case CMIDI2_STATUS_PAF:
-                        m2 = cmidi2_ump_midi2_paf(context->group, channel, byte2, byte3 << 25);
+                    case CMIDI2_CC_NRPN_MSB:
+                        context->context_nrpn = (context->context_nrpn & 0xFF) | byte3 << 8;
+                        skipEmitUmp = true;
                         break;
-                    case CMIDI2_STATUS_CC:
-                        switch (byte2) {
-                        case CMIDI2_CC_RPN_MSB:
-                            context->context_rpn = (context->context_rpn & 0xFF) | (byte3 << 8);
-                            skipEmitUmp = true;
-                            break;
-                        case CMIDI2_CC_RPN_LSB:
-                            context->context_rpn = (context->context_rpn & 0xFF00) | byte3;
-                            skipEmitUmp = true;
-                            break;
-                        case CMIDI2_CC_NRPN_MSB:
-                            context->context_nrpn = (context->context_nrpn & 0xFF) | byte3 << 8;
-                            skipEmitUmp = true;
-                            break;
-                        case CMIDI2_CC_NRPN_LSB:
-                            context->context_nrpn = (context->context_nrpn & 0xFF00) | byte3;
-                            skipEmitUmp = true;
-                            break;
-                        case CMIDI2_CC_DTE_MSB:
-                            context->context_dte = (context->context_dte & 0xFF) | (byte3 << 8);
+                    case CMIDI2_CC_NRPN_LSB:
+                        context->context_nrpn = (context->context_nrpn & 0xFF00) | byte3;
+                        skipEmitUmp = true;
+                        break;
+                    case CMIDI2_CC_DTE_MSB:
+                        context->context_dte = (context->context_dte & 0xFF) | (byte3 << 8);
 
-                            if (context->allow_reordered_dte && (context->context_dte & 0x8080) == 0)
-                                m2 = cmidi2_internal_convert_midi1_dte_to_ump(context, channel);
-                            else
-                                skipEmitUmp = true;
-
-                            break;
-                        case CMIDI2_CC_DTE_LSB:
-                            context->context_dte = (context->context_dte & 0xFF00) | byte3;
-
-                            if ((context->context_dte & 0x8000) && !context->allow_reordered_dte)
-                                return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
-                            if ((context->context_rpn & 0x8080) && (context->context_nrpn & 0x8080))
-                                return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
+                        if (context->allow_reordered_dte && (context->context_dte & 0x8080) == 0)
                             m2 = cmidi2_internal_convert_midi1_dte_to_ump(context, channel);
+                        else
+                            skipEmitUmp = true;
 
-                            break;
-                        case CMIDI2_CC_BANK_SELECT:
-                            context->context_bank = (context->context_bank & 0xFF) | (byte3 << 8);
-                            skipEmitUmp = true;
-                            break;
-                        case CMIDI2_CC_BANK_SELECT_LSB:
-                            context->context_bank = (context->context_bank & 0xFF00) | byte3;
-                            skipEmitUmp = true;
-                            break;
-                        default:
-                            m2 = cmidi2_ump_midi2_cc(context->group, channel, byte2, byte3 << 25);
-                            break;
-                        }
                         break;
-                    case CMIDI2_STATUS_PROGRAM:
-                        bankMsbValid = (context->context_bank & 0x8000) == 0;
-                        bankLsbValid = (context->context_bank & 0x80) == 0;
-                        bankValid = bankMsbValid || bankLsbValid;
-                        m2 = cmidi2_ump_midi2_program(context->group, channel,
-                            bankValid ? CMIDI2_PROGRAM_CHANGE_OPTION_BANK_VALID : CMIDI2_PROGRAM_CHANGE_OPTION_NONE,
-                            byte2, bankMsbValid ? context->context_bank >> 8 : 0, bankLsbValid ? context->context_bank & 0x7F : 0);
-                        context->context_bank = 0x8080;
+                    case CMIDI2_CC_DTE_LSB:
+                        context->context_dte = (context->context_dte & 0xFF00) | byte3;
+
+                        if ((context->context_dte & 0x8000) && !context->allow_reordered_dte)
+                            return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
+                        if ((context->context_rpn & 0x8080) && (context->context_nrpn & 0x8080))
+                            return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
+                        m2 = cmidi2_internal_convert_midi1_dte_to_ump(context, channel);
+
                         break;
-                    case CMIDI2_STATUS_CAF:
-                        m2 = cmidi2_ump_midi2_caf(context->group, channel, byte2 << 25);
+                    case CMIDI2_CC_BANK_SELECT:
+                        context->context_bank = (context->context_bank & 0xFF) | (byte3 << 8);
+                        skipEmitUmp = true;
                         break;
-                    case CMIDI2_STATUS_PITCH_BEND:
-                        // Note: Pitch Bend values in the MIDI 1.0 Protocol are presented as Little Endian.
-                        m2 = cmidi2_ump_midi2_pitch_bend_direct(context->group, channel, ((byte3 << 7) + byte2) << 18);
+                    case CMIDI2_CC_BANK_SELECT_LSB:
+                        context->context_bank = (context->context_bank & 0xFF00) | byte3;
+                        skipEmitUmp = true;
                         break;
                     default:
-                        switch (status) {
-                            case CMIDI2_SYSTEM_STATUS_MIDI_TIME_CODE:
-                            case CMIDI2_SYSTEM_STATUS_SONG_SELECT:
-                                    len = 2;
-                                    m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
-                                break;
-                            case CMIDI2_SYSTEM_STATUS_SONG_POSITION:
-                                    len = 3;
-                                    m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
-                                    break;
-                            case CMIDI2_SYSTEM_STATUS_TUNE_REQUEST:
-                            case CMIDI2_SYSTEM_STATUS_TIMING_CLOCK:
-                            case CMIDI2_SYSTEM_STATUS_START:
-                            case CMIDI2_SYSTEM_STATUS_STOP:
-                            case CMIDI2_SYSTEM_STATUS_ACTIVE_SENSING:
-                            case CMIDI2_SYSTEM_STATUS_RESET:
-                                    len = 1;
-                                    m2 = cmidi2_ump_system_message(context->group, status, 0, 0);
-                                    break;
-                            default:
-                                return CMIDI2_CONVERSION_RESULT_INVALID_STATUS;
-                        }
+                        m2 = cmidi2_ump_midi2_cc(context->group, channel, byte2, byte3 << 25);
                         break;
+                    }
+                    break;
+                case CMIDI2_STATUS_PROGRAM:
+                    bankMsbValid = (context->context_bank & 0x8000) == 0;
+                    bankLsbValid = (context->context_bank & 0x80) == 0;
+                    bankValid = bankMsbValid || bankLsbValid;
+                    m2 = cmidi2_ump_midi2_program(context->group, channel,
+                                                  bankValid ? CMIDI2_PROGRAM_CHANGE_OPTION_BANK_VALID : CMIDI2_PROGRAM_CHANGE_OPTION_NONE,
+                                                  byte2, bankMsbValid ? context->context_bank >> 8 : 0, bankLsbValid ? context->context_bank & 0x7F : 0);
+                    context->context_bank = 0x8080;
+                    break;
+                case CMIDI2_STATUS_CAF:
+                    m2 = cmidi2_ump_midi2_caf(context->group, channel, byte2 << 25);
+                    break;
+                case CMIDI2_STATUS_PITCH_BEND:
+                    // Note: Pitch Bend values in the MIDI 1.0 Protocol are presented as Little Endian.
+                    m2 = cmidi2_ump_midi2_pitch_bend_direct(context->group, channel, ((byte3 << 7) + byte2) << 18);
+                    break;
+                default:
+                    switch (status) {
+                    case CMIDI2_SYSTEM_STATUS_MIDI_TIME_CODE:
+                    case CMIDI2_SYSTEM_STATUS_SONG_SELECT:
+                        len = 2;
+                        m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
+                        break;
+                    case CMIDI2_SYSTEM_STATUS_SONG_POSITION:
+                        len = 3;
+                        m2 = cmidi2_ump_system_message(context->group, status, byte2, byte3);
+                        break;
+                    case CMIDI2_SYSTEM_STATUS_TUNE_REQUEST:
+                    case CMIDI2_SYSTEM_STATUS_TIMING_CLOCK:
+                    case CMIDI2_SYSTEM_STATUS_START:
+                    case CMIDI2_SYSTEM_STATUS_STOP:
+                    case CMIDI2_SYSTEM_STATUS_ACTIVE_SENSING:
+                    case CMIDI2_SYSTEM_STATUS_RESET:
+                        len = 1;
+                        m2 = cmidi2_ump_system_message(context->group, status, 0, 0);
+                        break;
+                    default:
+                        return CMIDI2_CONVERSION_RESULT_INVALID_STATUS;
+                    }
+                    break;
                 }
                 if (!skipEmitUmp) {
-                    int platEndian = cmidi2_util_is_platform_little_endian() ?                             CMIDI2_TRANSLATOR_LITTLE_ENDIAN : CMIDI2_TRANSLATOR_BIG_ENDIAN;
-                    int actualEndian = context->ump_serialization_endianness != CMIDI2_TRANSLATOR_DEFAULT_ENDIAN ?
-                                        context->ump_serialization_endianness : platEndian;
+                    int platEndian = cmidi2_util_is_platform_little_endian() ? CMIDI2_TRANSLATOR_LITTLE_ENDIAN : CMIDI2_TRANSLATOR_BIG_ENDIAN;
+                    int actualEndian = context->ump_serialization_endianness != CMIDI2_TRANSLATOR_DEFAULT_ENDIAN ? context->ump_serialization_endianness : platEndian;
                     if (platEndian != actualEndian)
                         m2 = (((uint64_t) cmidi2_internal_swap_endian(m2 >> 32)) << 32) | cmidi2_internal_swap_endian(m2 & 0xFFFFFFFF);
                     *(uint32_t*) (dst + *dIdx) = m2 >> 32;
@@ -2393,7 +2379,7 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_midi1_to_ump(cmidi2_mid
     // so it is safe to judge that incomplete RPN/NRPN/DTE state at this state means invalid.
     if (context->context_rpn != 0x8080 || context->context_nrpn != 0x8080 || context->context_dte != 0x8080)
         return CMIDI2_CONVERSION_RESULT_INVALID_DTE_SEQUENCE;
-    
+
     return CMIDI2_CONVERSION_RESULT_OK;
 }
 
@@ -2408,7 +2394,7 @@ static int32_t cmidi2_internal_convert_jr_timestamp_to_timecode(int32_t deltaTim
 static size_t cmidi2_internal_add_midi1_delta_time(uint8_t* dst, cmidi2_midi_conversion_context* context, int32_t deltaTime) {
     if (!context || context->skip_delta_time)
         return 0;
-    size_t *dIdx = (size_t*) &context->midi1_proceeded_bytes;
+    size_t* dIdx = (size_t*) &context->midi1_proceeded_bytes;
     int32_t len = cmidi2_midi1_get_7bit_encoded_int_length(deltaTime);
     cmidi2_midi1_write_7bit_encoded_int(dst, deltaTime);
     *dIdx += len;
@@ -2419,8 +2405,7 @@ static size_t cmidi2_internal_add_midi1_delta_time(uint8_t* dst, cmidi2_midi_con
 /// It is a lengthy function, so it is recommended to wrap it in another non-inline function.
 static inline size_t cmidi2_convert_single_ump_to_timed_midi1(
     uint8_t* dst, size_t maxBytes, cmidi2_ump* ump, int32_t deltaTime,
-    cmidi2_midi_conversion_context* context, uint8_t* sysex7Buffer, size_t* sysex7BufferIndex)
-{
+    cmidi2_midi_conversion_context* context, uint8_t* sysex7Buffer, size_t* sysex7BufferIndex) {
     if (maxBytes < 1)
         return 0;
 
@@ -2431,9 +2416,9 @@ static inline size_t cmidi2_convert_single_ump_to_timed_midi1(
     uint8_t messageType = cmidi2_ump_get_message_type(ump);
     uint8_t statusCode = cmidi2_ump_get_status_code(ump); // may not apply, but won't break.
 
-#define CMIDI2_INTERNAL_ADD_DELTA_TIME \
-        dst += cmidi2_internal_add_midi1_delta_time(dst, context, deltaTime); \
-        dst[0] = statusCode | cmidi2_ump_get_channel(ump);
+#define CMIDI2_INTERNAL_ADD_DELTA_TIME                                    \
+    dst += cmidi2_internal_add_midi1_delta_time(dst, context, deltaTime); \
+    dst[0] = statusCode | cmidi2_ump_get_channel(ump);
 
     switch (messageType) {
     case CMIDI2_MESSAGE_TYPE_SYSTEM:
@@ -2616,16 +2601,16 @@ static inline size_t cmidi2_convert_single_ump_to_midi1(uint8_t* dst, size_t max
     return cmidi2_convert_single_ump_to_timed_midi1(dst, maxBytes, ump, 0, NULL, NULL, 0);
 }
 
-#define IS_JR_TIMESTAMP(ump) \
+#define IS_JR_TIMESTAMP(ump)                                            \
     (cmidi2_ump_get_message_type(ump) == CMIDI2_MESSAGE_TYPE_UTILITY && \
-    cmidi2_ump_get_status_code(ump) == CMIDI2_UTILITY_STATUS_JR_TIMESTAMP)
+     cmidi2_ump_get_status_code(ump) == CMIDI2_UTILITY_STATUS_JR_TIMESTAMP)
 
 static enum cmidi2_midi_conversion_result cmidi2_convert_ump_to_midi1(cmidi2_midi_conversion_context* context) {
     uint8_t* dst = (uint8_t*) context->midi1;
     size_t sLen = context->ump_num_bytes;
     size_t dLen = context->midi1_num_bytes;
-    size_t *sIdx = (size_t*) &context->ump_proceeded_bytes;
-    size_t *dIdx = (size_t*) &context->midi1_proceeded_bytes;
+    size_t* sIdx = (size_t*) &context->ump_proceeded_bytes;
+    size_t* dIdx = (size_t*) &context->midi1_proceeded_bytes;
     uint8_t sysex7_buffer[1024];
     size_t sysex7_buffer_index = 0;
 
@@ -2637,8 +2622,7 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_ump_to_midi1(cmidi2_mid
             if (IS_JR_TIMESTAMP(ump)) {
                 if (!context->skip_delta_time)
                     deltaTimeInJRTimestamp += cmidi2_ump_get_jr_timestamp_timestamp(ump);
-            }
-            else
+            } else
                 break;
             *sIdx += 4; // 4 = sizeof JR Timestamp message
         } while (*sIdx < sLen);
@@ -2662,7 +2646,7 @@ static enum cmidi2_midi_conversion_result cmidi2_convert_ump_to_midi1(cmidi2_mid
                     cmidi2_internal_add_midi1_delta_time(dst + *dIdx, context, deltaTime);
                 dst[*dIdx] = 0xF0;
                 *dIdx += 1;
-                memcpy(dst+ *dIdx, sysex7_buffer, sysex7_buffer_index);
+                memcpy(dst + *dIdx, sysex7_buffer, sysex7_buffer_index);
                 *dIdx += sysex7_buffer_index;
                 sysex7_buffer_index = 0;
                 dst[*dIdx] = 0xF7;
@@ -2684,15 +2668,13 @@ typedef struct cmidi2_ump_forge {
     size_t offset;
 } cmidi2_ump_forge;
 
-static inline void cmidi2_ump_forge_init(cmidi2_ump_forge *forge, cmidi2_ump* buffer, size_t capacityInBytes)
-{
+static inline void cmidi2_ump_forge_init(cmidi2_ump_forge* forge, cmidi2_ump* buffer, size_t capacityInBytes) {
     forge->ump = buffer;
     forge->capacity = capacityInBytes;
     forge->offset = 0;
 }
 
-static inline bool cmidi2_ump_forge_add_packet_32(cmidi2_ump_forge* forge, uint32_t ump)
-{
+static inline bool cmidi2_ump_forge_add_packet_32(cmidi2_ump_forge* forge, uint32_t ump) {
     int size = 4;
     if (forge->offset + size > forge->capacity)
         return false;
@@ -2702,8 +2684,7 @@ static inline bool cmidi2_ump_forge_add_packet_32(cmidi2_ump_forge* forge, uint3
     return true;
 }
 
-static inline bool cmidi2_ump_forge_add_packet_64(cmidi2_ump_forge* forge, uint64_t ump)
-{
+static inline bool cmidi2_ump_forge_add_packet_64(cmidi2_ump_forge* forge, uint64_t ump) {
     int size = 8;
     if (forge->offset + size > forge->capacity)
         return false;
@@ -2713,8 +2694,7 @@ static inline bool cmidi2_ump_forge_add_packet_64(cmidi2_ump_forge* forge, uint6
     return true;
 }
 
-static inline bool cmidi2_ump_forge_add_packet_128(cmidi2_ump_forge* forge, uint64_t ump1, uint64_t ump2)
-{
+static inline bool cmidi2_ump_forge_add_packet_128(cmidi2_ump_forge* forge, uint64_t ump1, uint64_t ump2) {
     int size = 16;
     if (forge->offset + size > forge->capacity)
         return false;
@@ -2724,8 +2704,7 @@ static inline bool cmidi2_ump_forge_add_packet_128(cmidi2_ump_forge* forge, uint
     return true;
 }
 
-static inline bool cmidi2_ump_forge_add_single_packet(cmidi2_ump_forge* forge, cmidi2_ump* ump)
-{
+static inline bool cmidi2_ump_forge_add_single_packet(cmidi2_ump_forge* forge, cmidi2_ump* ump) {
     int size = cmidi2_ump_get_message_size_bytes(ump);
     if (forge->offset + size > forge->capacity)
         return false;
@@ -2734,8 +2713,7 @@ static inline bool cmidi2_ump_forge_add_single_packet(cmidi2_ump_forge* forge, c
     return true;
 }
 
-static inline bool cmidi2_ump_forge_add_packets(cmidi2_ump_forge* forge, cmidi2_ump* ump, int32_t size)
-{
+static inline bool cmidi2_ump_forge_add_packets(cmidi2_ump_forge* forge, cmidi2_ump* ump, int32_t size) {
     if (forge->offset + size > forge->capacity)
         return false;
     memcpy((uint8_t*) forge->ump + forge->offset, ump, size);
@@ -2746,15 +2724,15 @@ static inline bool cmidi2_ump_forge_add_packets(cmidi2_ump_forge* forge, cmidi2_
 // UMP sequence merger
 
 static inline bool cmidi2_internal_ump_merge_sequence_write_delta_time(int32_t timestamp1, int32_t timestamp2,
-                                                             int32_t* lastTimestamp,
-                                                             void* dst, int32_t *dIdx, size_t dstSize) {
+                                                                       int32_t* lastTimestamp,
+                                                                       void* dst, int32_t* dIdx, size_t dstSize) {
     int32_t deltaTime = (timestamp1 <= timestamp2 ? timestamp1 : timestamp2) - *lastTimestamp;
     uint8_t jrTSSize = deltaTime / 0x10000 + (deltaTime % 0x10000 ? 1 : 0);
-    if (*dIdx + jrTSSize * 4 > (int64_t)dstSize)
+    if (*dIdx + jrTSSize * 4 > (int64_t) dstSize)
         return false;
     for (int32_t dt = deltaTime; dt > 0; dt -= 0x10000) {
         cmidi2_ump_write32((cmidi2_ump*) ((uint8_t*) dst + *dIdx),
-        cmidi2_ump_jr_timestamp_direct(deltaTime > 0xFFFF ? 0xFFFF : deltaTime));
+                           cmidi2_ump_jr_timestamp_direct(deltaTime > 0xFFFF ? 0xFFFF : deltaTime));
         *dIdx += 4;
     }
     *lastTimestamp += deltaTime;
@@ -2762,8 +2740,8 @@ static inline bool cmidi2_internal_ump_merge_sequence_write_delta_time(int32_t t
 }
 
 static inline size_t cmidi2_ump_merge_sequences(cmidi2_ump* dst, size_t dstCapacity,
-                                              cmidi2_ump* seq1, size_t seq1Size,
-                                              cmidi2_ump* seq2, size_t seq2Size) {
+                                                cmidi2_ump* seq1, size_t seq1Size,
+                                                cmidi2_ump* seq2, size_t seq2Size) {
     int32_t dIdx = 0, seq1Idx = 0, seq2Idx = 0;
     int32_t timestamp1 = 0, timestamp2 = 0, lastTimestamp = 0;
     while (true) {
@@ -2772,7 +2750,7 @@ static inline size_t cmidi2_ump_merge_sequences(cmidi2_ump* dst, size_t dstCapac
                cmidi2_ump_get_status_code(s1) == CMIDI2_UTILITY_STATUS_JR_TIMESTAMP) {
             timestamp1 += cmidi2_ump_get_jr_timestamp_timestamp(s1);
             seq1Idx += 4;
-            if (seq1Idx >= (int64_t)seq1Size)
+            if (seq1Idx >= (int64_t) seq1Size)
                 break;
             s1 = (cmidi2_ump*) ((uint8_t*) seq1 + seq1Idx);
         }
@@ -2781,11 +2759,11 @@ static inline size_t cmidi2_ump_merge_sequences(cmidi2_ump* dst, size_t dstCapac
                cmidi2_ump_get_status_code(s2) == CMIDI2_UTILITY_STATUS_JR_TIMESTAMP) {
             timestamp2 += cmidi2_ump_get_jr_timestamp_timestamp(s2);
             seq2Idx += 4;
-            if (seq2Idx >= (int64_t)seq2Size)
+            if (seq2Idx >= (int64_t) seq2Size)
                 break;
             s2 = (cmidi2_ump*) ((uint8_t*) seq2 + seq2Idx);
         }
-        if (seq1Idx >= (int64_t)seq1Size || seq2Idx >= (int64_t)seq2Size)
+        if (seq1Idx >= (int64_t) seq1Size || seq2Idx >= (int64_t) seq2Size)
             break;
         if (!cmidi2_internal_ump_merge_sequence_write_delta_time(
                 timestamp1, timestamp2, &lastTimestamp, dst, &dIdx, dstCapacity))
@@ -2812,19 +2790,18 @@ static inline size_t cmidi2_ump_merge_sequences(cmidi2_ump* dst, size_t dstCapac
     if (!cmidi2_internal_ump_merge_sequence_write_delta_time(
             timestamp1, timestamp2, &lastTimestamp, dst, &dIdx, dstCapacity))
         return dIdx;
-    if (seq1Idx < (int64_t)seq1Size && dIdx + (int64_t)seq1Size - seq1Idx < (int64_t)dstCapacity) {
+    if (seq1Idx < (int64_t) seq1Size && dIdx + (int64_t) seq1Size - seq1Idx < (int64_t) dstCapacity) {
         cmidi2_ump* sp = (cmidi2_ump*) ((uint8_t*) seq1 + seq1Idx);
         memcpy((uint8_t*) dst + dIdx, sp, seq1Size - seq1Idx);
         dIdx += seq1Size - seq1Idx;
     }
-    if (seq2Idx < (int64_t)seq2Size && dIdx + (int64_t)seq2Size - seq2Idx < (int64_t)dstCapacity) {
+    if (seq2Idx < (int64_t) seq2Size && dIdx + (int64_t) seq2Size - seq2Idx < (int64_t) dstCapacity) {
         cmidi2_ump* sp = (cmidi2_ump*) ((uint8_t*) seq2 + seq2Idx);
         memcpy((uint8_t*) dst + dIdx, sp, seq2Size - seq2Idx);
         dIdx += seq2Size - seq2Idx;
     }
     return dIdx;
 }
-
 
 #ifdef __cplusplus
 }

--- a/cmidi2.h
+++ b/cmidi2.h
@@ -708,14 +708,14 @@ static inline void cmidi2_ump_sysex_get_packet_of(uint64_t* result1, uint64_t* r
 
     enum cmidi2_sysex_status status;
     uint8_t size;
-    if (numBytes <= radix) {
+    if (numBytes <= (size_t)radix) {
         status = CMIDI2_SYSEX_IN_ONE_UMP;
         size = numBytes; // single packet message
     } else if (index == 0) {
         status = CMIDI2_SYSEX_START;
         size = radix;
     } else {
-        uint8_t isEnd = index == cmidi2_ump_sysex_get_num_packets(numBytes, radix) - 1;
+        uint8_t isEnd = (size_t)index == cmidi2_ump_sysex_get_num_packets(numBytes, radix) - 1;
         if (isEnd) {
             size = numBytes % radix ? numBytes % radix : radix;
             status = CMIDI2_SYSEX_END;
@@ -934,7 +934,7 @@ static inline void cmidi2_ump_flex_data_get_packet_of(uint8_t group, uint8_t add
         format = CMIDI2_SYSEX_START;
         size = radix;
     } else {
-        uint8_t isEnd = currentPacket == cmidi2_ump_sysex_get_num_packets(numBytes, radix) - 1;
+        uint8_t isEnd = (size_t)currentPacket == cmidi2_ump_sysex_get_num_packets(numBytes, radix) - 1;
         if (isEnd) {
             size = numBytes % radix ? numBytes % radix : radix;
             format = CMIDI2_SYSEX_END;

--- a/cmidi2_test.c
+++ b/cmidi2_test.c
@@ -872,7 +872,10 @@ void testMidi1MessageSizes ()
     uint8_t a7[] = {0xF0, 0x7E, 0x7F, 1, 2, 3, 4, 5, 6, 7, 0xF7};
     assert(cmidi2_midi1_get_message_size(a7, 11) == 11);  // Sysex
     uint8_t a8[] = {0xFF, 2, 0, 1};
-    assert(cmidi2_midi1_get_message_size(a8, 4) == 4);  // Meta
+    assert(cmidi2_midi1_get_message_size_smf(a8, 4) == 4); // Meta (SMF)
+    uint8_t a9[] = {0xFF};
+    assert(cmidi2_midi1_get_message_size_live(a9, 1) == 1); // Reset (Live MIDI)
+    assert(cmidi2_midi1_get_message_size(a9, 1) == 1);      // Size without suffix is for live MIDI
 }
 
 void testMidi1Write7BitEncodedInt ()


### PR DESCRIPTION
note: this assumes that the clang-format PR is merged

A lot of fixes I did while trying to get the following test cases to cleanly round-trip:

```
      {"SysEx Short", {0xF0, 0x7E, 0x00, 0x01, 0x02, 0xF7}},
      {"SysEx Long", {0xF0, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0xF7}},

      {"Song Select", {0xF3, 0x05}},             // Song 5
      {"MTC Quarter Frame", {0xF1, 0x20}},       // Type 1, Value 0
      {"Song Position Ptr", {0xF2, 0x00, 0x01}}, // LSB 00, MSB 01
      // 0xF4, 0xF5 are undefined
      {"Tune Request", {0xF6}},

      {"Timing Clock", {0xF8}},
      {"Start", {0xFA}},
      {"Continue", {0xFB}},
      {"Stop", {0xFC}},
      // 0xF9, 0xFD are undefined
      {"Active Sensing", {0xFE}},
      {"Reset", {0xFF}},

      {"Note Off", {0x80, 0x3C, 0x00}},          // Ch 1, Note 60, Vel 0
      {"Note On", {0x90, 0x3C, 0x64}},           // Ch 1, Note 60, Vel 100
      {"Poly Key Pressure", {0xA1, 0x3C, 0x7F}}, // Ch 2, Note 60, Val 127
      {"Control Change", {0xB2, 0x07, 0x64}},    // Ch 3, CC 7, Val 100
      {"Program Change", {0xC3, 0x0A}},          // Ch 4, Prog 10
      {"Channel Pressure", {0xD4, 0x40}},        // Ch 5, Val 64
      {"Pitch Bend", {0xE5, 0x00, 0x40}},        // Ch 6, Center (LSB 00, MSB 40)
```

Most of those were failing due to various small issues in the conversion code.

One thing necessitates what I think is a necessary change in behaviour: the cmidi2_midi1_get_message_size assumed that the input was SMF.
That said, it seems that the conversion code was built with live input in mind considering that is_smf is unimplemented. I'd assume that most users of this library are going to use it for live input.

I created two explicit functions:
cmidi2_midi1_get_message_size_smf and cmidi2_midi1_get_message_size_live that allows users to choose the behaviour they want explicitly, and changed cmidi2_midi1_get_message_size to refer to the "live" one.